### PR TITLE
updated quantifier for NAME_PATTERN to actually reflect allowed names

### DIFF
--- a/dough-skins/src/main/java/io/github/bakedlibs/dough/skins/UUIDLookup.java
+++ b/dough-skins/src/main/java/io/github/bakedlibs/dough/skins/UUIDLookup.java
@@ -27,7 +27,7 @@ public class UUIDLookup {
     private static final Pattern UUID_PATTERN = Pattern.compile("(\\w{8})(\\w{4})(\\w{4})(\\w{4})(\\w{12})");
     private static final JsonParser JSON_PARSER = new JsonParser();
     private static final String ERROR_TOKEN = "error";
-    private static final Pattern NAME_PATTERN = Pattern.compile("[\\w]+");
+    private static final Pattern NAME_PATTERN = Pattern.compile("\\w{3,16}");
 
     private UUIDLookup() {}
 


### PR DESCRIPTION
The previous pattern allowed for illegal usernames, this one doesn't.