### PR TITLE
Add Quarters protection module

### DIFF
--- a/dough-api/pom.xml
+++ b/dough-api/pom.xml
@@ -179,6 +179,10 @@
             <id>logblock-repo</id>
             <url>https://www.iani.de/nexus/content/repositories/snapshots/</url>
         </repository>
+        <repository>
+            <id>towny-repo</id>
+            <url>https://repo.glaremasters.me/repository/towny/</url>
+        </repository>
     </repositories>
 
     <dependencies>
@@ -335,9 +339,9 @@
 
         <!-- Towny -->
         <dependency>
-            <groupId>com.github.LlmDl</groupId>
-            <artifactId>Towny</artifactId>
-            <version>1b86d017c5</version>
+            <groupId>com.palmergames.bukkit.towny</groupId>
+            <artifactId>towny</artifactId>
+            <version>0.100.0.0</version>
             <scope>provided</scope>
         </dependency>
 
@@ -422,6 +426,14 @@
             <groupId>com.github.WiIIiam278</groupId>
             <artifactId>HuskTowns</artifactId>
             <version>1.7</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Quarters -->
+        <dependency>
+            <groupId>com.github.Fruitloopins</groupId>
+            <artifactId>Quarters</artifactId>
+            <version>-69bf391439-1</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/dough-protection/pom.xml
+++ b/dough-protection/pom.xml
@@ -50,6 +50,10 @@
             <id>logblock-repo</id>
             <url>https://www.iani.de/nexus/content/repositories/snapshots/</url>
         </repository>
+        <repository>
+            <id>towny-repo</id>
+            <url>https://repo.glaremasters.me/repository/towny/</url>
+        </repository>
     </repositories>
 
     <dependencies>
@@ -144,9 +148,9 @@
 
         <!-- Towny -->
         <dependency>
-            <groupId>com.github.LlmDl</groupId>
-            <artifactId>Towny</artifactId>
-            <version>1b86d017c5</version>
+            <groupId>com.palmergames.bukkit.towny</groupId>
+            <artifactId>towny</artifactId>
+            <version>0.100.0.0</version>
             <scope>provided</scope>
         </dependency>
 
@@ -234,6 +238,13 @@
             <scope>provided</scope>
         </dependency>
 
+        <!-- Quarters -->
+        <dependency>
+            <groupId>com.github.Fruitloopins</groupId>
+            <artifactId>Quarters</artifactId>
+            <version>-69bf391439-1</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/dough-protection/src/main/java/io/github/bakedlibs/dough/protection/ProtectionManager.java
+++ b/dough-protection/src/main/java/io/github/bakedlibs/dough/protection/ProtectionManager.java
@@ -78,8 +78,12 @@ public final class ProtectionManager {
 
         // We sadly cannot use ModuleName::new as this would load the class into memory prematurely
         registerModule(pm, "WorldGuard", worldGuard -> new WorldGuardProtectionModule(worldGuard));
-        registerModule(pm, "Quarters", quarters -> new QuartersProtectionModule(quarters));
-        registerModule(pm, "Towny", towny -> new TownyProtectionModule(towny));
+        // Only load the pure Towny module if Quarters is not present on the server.
+        if (pm.isPluginEnabled("Quarters")) {
+            registerModule(pm, "Quarters", quarters -> new QuartersProtectionModule(quarters));
+        } else {
+            registerModule(pm, "Towny", towny -> new TownyProtectionModule(towny));
+        }
         registerModule(pm, "GriefPrevention", griefPrevention -> new GriefPreventionProtectionModule(griefPrevention));
         registerModule(pm, "LWC", lwc -> new LWCProtectionModule(lwc));
         registerModule(pm, "PreciousStones", preciousStones -> new PreciousStonesProtectionModule(preciousStones));

--- a/dough-protection/src/main/java/io/github/bakedlibs/dough/protection/ProtectionManager.java
+++ b/dough-protection/src/main/java/io/github/bakedlibs/dough/protection/ProtectionManager.java
@@ -33,6 +33,7 @@ import io.github.bakedlibs.dough.protection.modules.PreciousStonesProtectionModu
 import io.github.bakedlibs.dough.protection.modules.RedProtectProtectionModule;
 import io.github.bakedlibs.dough.protection.modules.TownyProtectionModule;
 import io.github.bakedlibs.dough.protection.modules.WorldGuardProtectionModule;
+import io.github.bakedlibs.dough.protection.modules.QuartersProtectionModule;
 
 /**
  * This Class provides a nifty API for plugins to query popular protection plugins.
@@ -91,6 +92,7 @@ public final class ProtectionManager {
         registerModule(pm, "FunnyGuilds", funnyGuilds -> new FunnyGuildsProtectionModule(funnyGuilds));
         registerModule(pm, "PlotSquared", plotSquared -> new PlotSquaredProtectionModule(plotSquared));
         registerModule(pm, "HuskTowns", huskTowns -> new HuskTownsProtectionModule(huskTowns));
+        registerModule(pm, "Quarters", quarters -> new QuartersProtectionModule(quarters));
 
         /*
          * The following Plugins work by utilising one of the above listed

--- a/dough-protection/src/main/java/io/github/bakedlibs/dough/protection/ProtectionManager.java
+++ b/dough-protection/src/main/java/io/github/bakedlibs/dough/protection/ProtectionManager.java
@@ -78,6 +78,7 @@ public final class ProtectionManager {
 
         // We sadly cannot use ModuleName::new as this would load the class into memory prematurely
         registerModule(pm, "WorldGuard", worldGuard -> new WorldGuardProtectionModule(worldGuard));
+        registerModule(pm, "Quarters", quarters -> new QuartersProtectionModule(quarters));
         registerModule(pm, "Towny", towny -> new TownyProtectionModule(towny));
         registerModule(pm, "GriefPrevention", griefPrevention -> new GriefPreventionProtectionModule(griefPrevention));
         registerModule(pm, "LWC", lwc -> new LWCProtectionModule(lwc));
@@ -92,7 +93,6 @@ public final class ProtectionManager {
         registerModule(pm, "FunnyGuilds", funnyGuilds -> new FunnyGuildsProtectionModule(funnyGuilds));
         registerModule(pm, "PlotSquared", plotSquared -> new PlotSquaredProtectionModule(plotSquared));
         registerModule(pm, "HuskTowns", huskTowns -> new HuskTownsProtectionModule(huskTowns));
-        registerModule(pm, "Quarters", quarters -> new QuartersProtectionModule(quarters));
 
         /*
          * The following Plugins work by utilising one of the above listed

--- a/dough-protection/src/main/java/io/github/bakedlibs/dough/protection/modules/QuartersProtectionModule.java
+++ b/dough-protection/src/main/java/io/github/bakedlibs/dough/protection/modules/QuartersProtectionModule.java
@@ -51,21 +51,22 @@ public class QuartersProtectionModule implements ProtectionModule {
         ActionType townyAction = convert(action);
         PlayerCache cache = PlayerCacheUtil.getCache(player);
         boolean allowed = isInteractionAllowed(player, townyAction, l);
-
         // Update Towny's permission cache, or else the Towny ProtectionModule may override.
-        switch (townyAction) {
-            case BUILD:
-                cache.setBuildPermission(l.getBlock().getType(), allowed);
-                break;
-            case SWITCH:
-                cache.setSwitchPermission(l.getBlock().getType(), allowed);
-                break;
-            case DESTROY:
-                cache.setDestroyPermission(l.getBlock().getType(), allowed);
-                break;
-            case ITEM_USE:
-                cache.setItemUsePermission(l.getBlock().getType(), allowed);
-                break;
+        if (allowed) {
+            switch (townyAction) {
+                case BUILD:
+                    cache.setBuildPermission(l.getBlock().getType(), true);
+                    break;
+                case SWITCH:
+                    cache.setSwitchPermission(l.getBlock().getType(), true);
+                    break;
+                case DESTROY:
+                    cache.setDestroyPermission(l.getBlock().getType(), true);
+                    break;
+                case ITEM_USE:
+                    cache.setItemUsePermission(l.getBlock().getType(), true);
+                    break;
+            }
         }
 
         return allowed;
@@ -74,12 +75,12 @@ public class QuartersProtectionModule implements ProtectionModule {
     private boolean isInteractionAllowed(Player player, ActionType type, Location l) {
         Quarter quarter = QuartersAPI.getInstance().getQuarter(l);
         if (quarter == null) {
-            return false;
+            return PlayerCacheUtil.getCachePermission(player, l, l.getBlock().getType(), type);
         }
 
         Resident resident = TownyAPI.getInstance().getResident(player.getUniqueId());
         if (resident == null) {
-            return false;
+            return PlayerCacheUtil.getCachePermission(player, l, l.getBlock().getType(), type);
         }
 
         if (quarter.getOwnerResident().equals(resident) || quarter.getTrustedResidents().contains(resident)) {

--- a/dough-protection/src/main/java/io/github/bakedlibs/dough/protection/modules/QuartersProtectionModule.java
+++ b/dough-protection/src/main/java/io/github/bakedlibs/dough/protection/modules/QuartersProtectionModule.java
@@ -1,0 +1,114 @@
+package io.github.bakedlibs.dough.protection.modules;
+
+import com.palmergames.bukkit.towny.TownyAPI;
+import com.palmergames.bukkit.towny.object.Resident;
+import com.palmergames.bukkit.towny.object.TownyPermission.ActionType;
+import io.github.bakedlibs.dough.protection.Interaction;
+import io.github.bakedlibs.dough.protection.ProtectionModule;
+import net.earthmc.quarters.api.QuartersAPI;
+import net.earthmc.quarters.object.Quarter;
+import org.bukkit.Location;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
+
+import javax.annotation.Nonnull;
+
+
+/**
+ * Protection handling module for Quarters
+ *
+ * @author Fruitloopins
+ * @author galacticwarrior9
+ */
+public class QuartersProtectionModule implements ProtectionModule {
+
+    private final Plugin plugin;
+
+    public QuartersProtectionModule(@Nonnull Plugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public Plugin getPlugin() {
+        return plugin;
+    }
+
+    @Override
+    public void load() {
+        // We don't need to load any APIs, everything is static
+    }
+
+    @Override
+    public boolean hasPermission(OfflinePlayer p, Location l, Interaction action) {
+        if (!(p instanceof Player)) {
+            return false;
+        }
+
+        Player player = (Player) p;
+        return isInteractionAllowed(player, convert(action), l);
+    }
+
+    private boolean isInteractionAllowed(Player player, ActionType type, Location l) {
+        Quarter quarter = QuartersAPI.getInstance().getQuarter(l);
+        if (quarter == null) {
+            return false;
+        }
+
+        Resident resident = TownyAPI.getInstance().getResident(player.getUniqueId());
+        if (resident == null) {
+            return false;
+        }
+
+        if (quarter.getOwnerResident().equals(resident) || quarter.getTrustedResidents().contains(resident)) {
+            return true;
+        }
+
+        switch (quarter.getType()) {
+            case COMMONS:
+                if (type != ActionType.SWITCH && type != ActionType.ITEM_USE) {
+                    return false;
+                }
+                return isAllowed(quarter, resident);
+            case PUBLIC:
+                return isAllowed(quarter, resident);
+            case STATION:
+                if (type != ActionType.ITEM_USE && type != ActionType.DESTROY && type != ActionType.SWITCH) {
+                    return false;
+                }
+                return isAllowed(quarter, resident);
+            case WORKSITE:
+                if (type != ActionType.BUILD && type != ActionType.DESTROY) {
+                    return false;
+                }
+                return isAllowed(quarter, resident);
+            default:
+                return false;
+        }
+    }
+
+    private boolean isAllowed(Quarter quarter, Resident resident) {
+        return quarter.isEmbassy() || (quarter.getTown() == resident.getTownOrNull());
+    }
+
+    /**
+     * Returns the corresponding Towny {@link ActionType} from the dough {@link Interaction}
+     *
+     * @param action The dough {@link Interaction}
+     * @return The corresponding Towny {@link ActionType}
+     */
+    private ActionType convert(Interaction action) {
+        switch (action) {
+            case INTERACT_BLOCK:
+            case INTERACT_ENTITY:
+            case ATTACK_PLAYER:
+            case ATTACK_ENTITY:
+                return ActionType.ITEM_USE;
+            case BREAK_BLOCK:
+                return ActionType.DESTROY;
+            case PLACE_BLOCK:
+            default:
+                return ActionType.BUILD;
+        }
+    }
+}

--- a/dough-protection/src/main/java/io/github/bakedlibs/dough/protection/modules/QuartersProtectionModule.java
+++ b/dough-protection/src/main/java/io/github/bakedlibs/dough/protection/modules/QuartersProtectionModule.java
@@ -1,8 +1,10 @@
 package io.github.bakedlibs.dough.protection.modules;
 
 import com.palmergames.bukkit.towny.TownyAPI;
+import com.palmergames.bukkit.towny.object.PlayerCache;
 import com.palmergames.bukkit.towny.object.Resident;
 import com.palmergames.bukkit.towny.object.TownyPermission.ActionType;
+import com.palmergames.bukkit.towny.utils.PlayerCacheUtil;
 import io.github.bakedlibs.dough.protection.Interaction;
 import io.github.bakedlibs.dough.protection.ProtectionModule;
 import net.earthmc.quarters.api.QuartersAPI;
@@ -16,7 +18,7 @@ import javax.annotation.Nonnull;
 
 
 /**
- * Protection handling module for Quarters
+ * Protection handling module for Quarters, a Towny add-on.
  *
  * @author Fruitloopins
  * @author galacticwarrior9
@@ -46,7 +48,27 @@ public class QuartersProtectionModule implements ProtectionModule {
         }
 
         Player player = (Player) p;
-        return isInteractionAllowed(player, convert(action), l);
+        ActionType townyAction = convert(action);
+        PlayerCache cache = PlayerCacheUtil.getCache(player);
+        boolean allowed = isInteractionAllowed(player, townyAction, l);
+
+        // Update Towny's permission cache, or else the Towny ProtectionModule may override.
+        switch (townyAction) {
+            case BUILD:
+                cache.setBuildPermission(l.getBlock().getType(), allowed);
+                break;
+            case SWITCH:
+                cache.setSwitchPermission(l.getBlock().getType(), allowed);
+                break;
+            case DESTROY:
+                cache.setDestroyPermission(l.getBlock().getType(), allowed);
+                break;
+            case ITEM_USE:
+                cache.setItemUsePermission(l.getBlock().getType(), allowed);
+                break;
+        }
+
+        return allowed;
     }
 
     private boolean isInteractionAllowed(Player player, ActionType type, Location l) {


### PR DESCRIPTION
This PR adds a protection module for [Quarters](https://github.com/Fruitloopins/Quarters) claims. This fixes permissions for Slimefun blocks inside Quarters claims.

While Quarters is a Towny add-on, it has its own claim types and an independent method of determining whether a player can interact with one of its claims. It therefore requires its own protection module. 

It is necessary for this module to load *instead* of the existing Towny module when Quarters is installed. Loading both leads to problems: as Slimefun instantly denies an interaction if any `ProtectionModule#hasPermission` returns `false`, running one before the other will lead to a premature conclusion about the permissibility of an interaction (the quarter will be checked before the plot, or vice versa). The Quarters module is functionally identical to the Towny module when there is no quarter at a location.

I have also updated the Towny repo to the official one, and bumped the Towny dependency version. This is required for the Quarters module and does not affect the Towny module. 

