### PR TITLE
feat: Add HuskClaims protection module & update HuskTowns module

### DIFF
--- a/dough-protection/pom.xml
+++ b/dough-protection/pom.xml
@@ -50,6 +50,10 @@
             <id>logblock-repo</id>
             <url>https://www.iani.de/nexus/content/repositories/snapshots/</url>
         </repository>
+        <repository>
+            <id>william278-repo</id>
+            <url>https://repo.william278.net/snapshots/</url>
+        </repository>
     </repositories>
 
     <dependencies>
@@ -228,9 +232,17 @@
 
         <!-- HuskTowns -->
         <dependency>
-            <groupId>net.william278</groupId>
-            <artifactId>HuskTowns</artifactId>
-            <version>2.5.3</version>
+            <groupId>net.william278.husktowns</groupId>
+            <artifactId>husktowns-bukkit</artifactId>
+            <version>3.0-988161b</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- HuskClaims -->
+        <dependency>
+            <groupId>net.william278.huskclaims</groupId>
+            <artifactId>huskclaims-bukkit</artifactId>
+            <version>1.0.2-e60150d</version>
             <scope>provided</scope>
         </dependency>
 

--- a/dough-protection/src/main/java/io/github/bakedlibs/dough/protection/ProtectionManager.java
+++ b/dough-protection/src/main/java/io/github/bakedlibs/dough/protection/ProtectionManager.java
@@ -9,6 +9,7 @@ import java.util.logging.Logger;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import io.github.bakedlibs.dough.protection.modules.*;
 import org.bukkit.Location;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.block.Block;
@@ -18,21 +19,6 @@ import org.bukkit.plugin.PluginManager;
 import io.github.bakedlibs.dough.common.DoughLogger;
 import io.github.bakedlibs.dough.protection.loggers.CoreProtectLogger;
 import io.github.bakedlibs.dough.protection.loggers.LogBlockLogger;
-import io.github.bakedlibs.dough.protection.modules.BentoBoxProtectionModule;
-import io.github.bakedlibs.dough.protection.modules.BlockLockerProtectionModule;
-import io.github.bakedlibs.dough.protection.modules.ChestProtectProtectionModule;
-import io.github.bakedlibs.dough.protection.modules.FactionsUUIDProtectionModule;
-import io.github.bakedlibs.dough.protection.modules.FunnyGuildsProtectionModule;
-import io.github.bakedlibs.dough.protection.modules.GriefPreventionProtectionModule;
-import io.github.bakedlibs.dough.protection.modules.HuskTownsProtectionModule;
-import io.github.bakedlibs.dough.protection.modules.LWCProtectionModule;
-import io.github.bakedlibs.dough.protection.modules.LandsProtectionModule;
-import io.github.bakedlibs.dough.protection.modules.LocketteProtectionModule;
-import io.github.bakedlibs.dough.protection.modules.PlotSquaredProtectionModule;
-import io.github.bakedlibs.dough.protection.modules.PreciousStonesProtectionModule;
-import io.github.bakedlibs.dough.protection.modules.RedProtectProtectionModule;
-import io.github.bakedlibs.dough.protection.modules.TownyProtectionModule;
-import io.github.bakedlibs.dough.protection.modules.WorldGuardProtectionModule;
 
 /**
  * This Class provides a nifty API for plugins to query popular protection plugins.
@@ -91,6 +77,7 @@ public final class ProtectionManager {
         registerModule(pm, "FunnyGuilds", funnyGuilds -> new FunnyGuildsProtectionModule(funnyGuilds));
         registerModule(pm, "PlotSquared", plotSquared -> new PlotSquaredProtectionModule(plotSquared));
         registerModule(pm, "HuskTowns", huskTowns -> new HuskTownsProtectionModule(huskTowns));
+        registerModule(pm, "HuskTowns", huskTowns -> new HuskClaimsProtectionModule(huskTowns));
 
         /*
          * The following Plugins work by utilising one of the above listed

--- a/dough-protection/src/main/java/io/github/bakedlibs/dough/protection/ProtectionManager.java
+++ b/dough-protection/src/main/java/io/github/bakedlibs/dough/protection/ProtectionManager.java
@@ -9,7 +9,15 @@ import java.util.logging.Logger;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
+import org.bukkit.Location;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.block.Block;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.plugin.PluginManager;
 
+import io.github.bakedlibs.dough.common.DoughLogger;
+import io.github.bakedlibs.dough.protection.loggers.CoreProtectLogger;
+import io.github.bakedlibs.dough.protection.loggers.LogBlockLogger;
 import io.github.bakedlibs.dough.protection.modules.BentoBoxProtectionModule;
 import io.github.bakedlibs.dough.protection.modules.BlockLockerProtectionModule;
 import io.github.bakedlibs.dough.protection.modules.ChestProtectProtectionModule;
@@ -26,15 +34,6 @@ import io.github.bakedlibs.dough.protection.modules.PreciousStonesProtectionModu
 import io.github.bakedlibs.dough.protection.modules.RedProtectProtectionModule;
 import io.github.bakedlibs.dough.protection.modules.TownyProtectionModule;
 import io.github.bakedlibs.dough.protection.modules.WorldGuardProtectionModule;
-import org.bukkit.Location;
-import org.bukkit.OfflinePlayer;
-import org.bukkit.block.Block;
-import org.bukkit.plugin.Plugin;
-import org.bukkit.plugin.PluginManager;
-
-import io.github.bakedlibs.dough.common.DoughLogger;
-import io.github.bakedlibs.dough.protection.loggers.CoreProtectLogger;
-import io.github.bakedlibs.dough.protection.loggers.LogBlockLogger;
 
 /**
  * This Class provides a nifty API for plugins to query popular protection plugins.

--- a/dough-protection/src/main/java/io/github/bakedlibs/dough/protection/ProtectionManager.java
+++ b/dough-protection/src/main/java/io/github/bakedlibs/dough/protection/ProtectionManager.java
@@ -92,7 +92,7 @@ public final class ProtectionManager {
         registerModule(pm, "FunnyGuilds", funnyGuilds -> new FunnyGuildsProtectionModule(funnyGuilds));
         registerModule(pm, "PlotSquared", plotSquared -> new PlotSquaredProtectionModule(plotSquared));
         registerModule(pm, "HuskTowns", huskTowns -> new HuskTownsProtectionModule(huskTowns));
-        registerModule(pm, "HuskTowns", huskTowns -> new HuskClaimsProtectionModule(huskTowns));
+        registerModule(pm, "HuskClaims", huskClaims -> new HuskClaimsProtectionModule(huskClaims));
 
         /*
          * The following Plugins work by utilising one of the above listed

--- a/dough-protection/src/main/java/io/github/bakedlibs/dough/protection/ProtectionManager.java
+++ b/dough-protection/src/main/java/io/github/bakedlibs/dough/protection/ProtectionManager.java
@@ -9,7 +9,23 @@ import java.util.logging.Logger;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import io.github.bakedlibs.dough.protection.modules.*;
+
+import io.github.bakedlibs.dough.protection.modules.BentoBoxProtectionModule;
+import io.github.bakedlibs.dough.protection.modules.BlockLockerProtectionModule;
+import io.github.bakedlibs.dough.protection.modules.ChestProtectProtectionModule;
+import io.github.bakedlibs.dough.protection.modules.FactionsUUIDProtectionModule;
+import io.github.bakedlibs.dough.protection.modules.FunnyGuildsProtectionModule;
+import io.github.bakedlibs.dough.protection.modules.GriefPreventionProtectionModule;
+import io.github.bakedlibs.dough.protection.modules.HuskTownsProtectionModule;
+import io.github.bakedlibs.dough.protection.modules.HuskClaimsProtectionModule;
+import io.github.bakedlibs.dough.protection.modules.LWCProtectionModule;
+import io.github.bakedlibs.dough.protection.modules.LandsProtectionModule;
+import io.github.bakedlibs.dough.protection.modules.LocketteProtectionModule;
+import io.github.bakedlibs.dough.protection.modules.PlotSquaredProtectionModule;
+import io.github.bakedlibs.dough.protection.modules.PreciousStonesProtectionModule;
+import io.github.bakedlibs.dough.protection.modules.RedProtectProtectionModule;
+import io.github.bakedlibs.dough.protection.modules.TownyProtectionModule;
+import io.github.bakedlibs.dough.protection.modules.WorldGuardProtectionModule;
 import org.bukkit.Location;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.block.Block;

--- a/dough-protection/src/main/java/io/github/bakedlibs/dough/protection/modules/HuskClaimsProtectionModule.java
+++ b/dough-protection/src/main/java/io/github/bakedlibs/dough/protection/modules/HuskClaimsProtectionModule.java
@@ -1,0 +1,75 @@
+package io.github.bakedlibs.dough.protection.modules;
+
+import io.github.bakedlibs.dough.protection.Interaction;
+import io.github.bakedlibs.dough.protection.ProtectionModule;
+import net.william278.huskclaims.api.BukkitHuskClaimsAPI;
+import net.william278.huskclaims.libraries.cloplib.operation.Operation;
+import net.william278.huskclaims.libraries.cloplib.operation.OperationType;
+import org.bukkit.Location;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.plugin.Plugin;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Protection handling module for HuskClaims
+ *
+ * @author William278
+ */
+public class HuskClaimsProtectionModule implements ProtectionModule {
+
+    private BukkitHuskClaimsAPI huskClaimsAPI;
+    private final Plugin plugin;
+
+    public HuskClaimsProtectionModule(@Nonnull Plugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public void load() {
+        huskClaimsAPI = BukkitHuskClaimsAPI.getInstance();
+    }
+
+    @Override
+    public Plugin getPlugin() {
+        return plugin;
+    }
+
+    @Override
+    public boolean hasPermission(OfflinePlayer p, Location l, Interaction action) {
+        // Offline player have no permissions
+        if (!p.isOnline()) {
+            return false;
+        }
+
+        // Convert the dough interaction to HuskClaims' ActionType and check via the API
+        return huskClaimsAPI.isOperationAllowed(Operation.of(
+                huskClaimsAPI.getOnlineUser(p.getPlayer()),
+                getHuskClaimsAction(action),
+                huskClaimsAPI.getPosition(l)
+        ));
+    }
+
+    /**
+     * Returns the corresponding HuskClaims {@link OperationType} from the dough {@link Interaction}
+     *
+     * @param doughAction The dough {@link Interaction}
+     * @return The corresponding HuskClaims {@link OperationType}
+     */
+    public @Nonnull OperationType getHuskClaimsAction(@Nonnull Interaction doughAction) {
+        switch (doughAction) {
+            case BREAK_BLOCK:
+                return OperationType.BLOCK_BREAK;
+            case PLACE_BLOCK:
+                return OperationType.BLOCK_PLACE;
+            case ATTACK_ENTITY:
+                return OperationType.PLAYER_DAMAGE_ENTITY;
+            case ATTACK_PLAYER:
+                return OperationType.PLAYER_DAMAGE_PLAYER;
+            case INTERACT_BLOCK:
+                return OperationType.BLOCK_INTERACT;
+            default:
+                return OperationType.ENTITY_INTERACT;
+        }
+    }
+}

--- a/dough-protection/src/main/java/io/github/bakedlibs/dough/protection/modules/HuskTownsProtectionModule.java
+++ b/dough-protection/src/main/java/io/github/bakedlibs/dough/protection/modules/HuskTownsProtectionModule.java
@@ -2,11 +2,9 @@ package io.github.bakedlibs.dough.protection.modules;
 
 import io.github.bakedlibs.dough.protection.Interaction;
 import io.github.bakedlibs.dough.protection.ProtectionModule;
-import net.william278.husktowns.api.HuskTownsAPI;
-import net.william278.husktowns.claim.Position;
-import net.william278.husktowns.claim.World;
-import net.william278.husktowns.listener.Operation;
-import net.william278.husktowns.user.OnlineUser;
+import net.william278.husktowns.api.BukkitHuskTownsAPI;
+import net.william278.husktowns.libraries.cloplib.operation.Operation;
+import net.william278.husktowns.libraries.cloplib.operation.OperationType;
 import org.bukkit.Location;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.plugin.Plugin;
@@ -20,7 +18,7 @@ import javax.annotation.Nonnull;
  */
 public class HuskTownsProtectionModule implements ProtectionModule {
 
-    private HuskTownsAPI huskTownsAPI;
+    private BukkitHuskTownsAPI huskTownsAPI;
     private final Plugin plugin;
 
     public HuskTownsProtectionModule(@Nonnull Plugin plugin) {
@@ -29,7 +27,7 @@ public class HuskTownsProtectionModule implements ProtectionModule {
 
     @Override
     public void load() {
-        huskTownsAPI = HuskTownsAPI.getInstance();
+        huskTownsAPI = BukkitHuskTownsAPI.getInstance();
     }
 
     @Override
@@ -46,38 +44,32 @@ public class HuskTownsProtectionModule implements ProtectionModule {
 
         // Convert the dough interaction to HuskTowns' ActionType and check via the API
         return huskTownsAPI.isOperationAllowed(Operation.of(
-                getOnlineUser(p), getHuskTownsAction(action), getPosition(l)));
-    }
-
-    private OnlineUser getOnlineUser(OfflinePlayer p) {
-        return huskTownsAPI.getOnlineUser(p.getPlayer());
-    }
-
-    private Position getPosition(Location l) {
-        org.bukkit.World w = l.getWorld();
-        return Position.at(l.getX(), l.getY(), l.getZ(), World.of(w.getUID(), w.getName(), w.getEnvironment().name()));
+                huskTownsAPI.getOnlineUser(p.getPlayer()),
+                getHuskTownsAction(action),
+                huskTownsAPI.getPosition(l)
+        ));
     }
 
     /**
-     * Returns the corresponding HuskTowns {@link Operation.Type} from the dough {@link Interaction}
+     * Returns the corresponding HuskTowns {@link OperationType} from the dough {@link Interaction}
      *
      * @param doughAction The dough {@link Interaction}
-     * @return The corresponding HuskTowns {@link Operation.Type}
+     * @return The corresponding HuskTowns {@link OperationType}
      */
-    public @Nonnull Operation.Type getHuskTownsAction(@Nonnull Interaction doughAction) {
+    public @Nonnull OperationType getHuskTownsAction(@Nonnull Interaction doughAction) {
         switch (doughAction) {
             case BREAK_BLOCK:
-                return Operation.Type.BLOCK_BREAK;
+                return OperationType.BLOCK_BREAK;
             case PLACE_BLOCK:
-                return Operation.Type.BLOCK_PLACE;
+                return OperationType.BLOCK_PLACE;
             case ATTACK_ENTITY:
-                return Operation.Type.PLAYER_DAMAGE_ENTITY;
+                return OperationType.PLAYER_DAMAGE_ENTITY;
             case ATTACK_PLAYER:
-                return Operation.Type.PLAYER_DAMAGE_PLAYER;
+                return OperationType.PLAYER_DAMAGE_PLAYER;
             case INTERACT_BLOCK:
-                return Operation.Type.BLOCK_INTERACT;
+                return OperationType.BLOCK_INTERACT;
             default:
-                return Operation.Type.ENTITY_INTERACT;
+                return OperationType.ENTITY_INTERACT;
         }
     }
 }


### PR DESCRIPTION
As per title. Adds a protection module for [HuskClaims](https://william278.net/project/huskclaims) and updates the module for [HuskTowns](https://william278.net/project/husktowns) to be compatible with v3.0 (both plugins use shaded+relocated versions of [Cloplib](https://github.com/WiIIiam278/ClopLib) for easier maintenance).