### PR TITLE
Update GriefPrevention module

### DIFF
--- a/dough-protection/pom.xml
+++ b/dough-protection/pom.xml
@@ -114,7 +114,7 @@
 
         <!-- GriefPrevention -->
         <dependency>
-            <groupId>com.github.TechFortress</groupId>
+            <groupId>com.github.GriefPrevention</groupId>
             <artifactId>GriefPrevention</artifactId>
             <version>16.18.1</version>
             <scope>provided</scope>

--- a/dough-protection/src/main/java/io/github/bakedlibs/dough/protection/modules/GriefPreventionProtectionModule.java
+++ b/dough-protection/src/main/java/io/github/bakedlibs/dough/protection/modules/GriefPreventionProtectionModule.java
@@ -1,22 +1,26 @@
 package io.github.bakedlibs.dough.protection.modules;
 
+import me.ryanhamshire.GriefPrevention.ClaimPermission;
 import org.bukkit.Location;
 import org.bukkit.OfflinePlayer;
+import org.bukkit.World;
 import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
 import org.bukkit.plugin.Plugin;
 
 import io.github.bakedlibs.dough.protection.Interaction;
 import io.github.bakedlibs.dough.protection.ProtectionModule;
 
 import me.ryanhamshire.GriefPrevention.Claim;
-import me.ryanhamshire.GriefPrevention.DataStore;
 import me.ryanhamshire.GriefPrevention.GriefPrevention;
 
 import javax.annotation.Nonnull;
 
 public class GriefPreventionProtectionModule implements ProtectionModule {
 
-    private DataStore dataStore;
+    private GriefPrevention griefPrevention;
+    private boolean useClaimPermission = false;
+
     private final Plugin plugin;
 
     public GriefPreventionProtectionModule(@Nonnull Plugin plugin) {
@@ -30,32 +34,72 @@ public class GriefPreventionProtectionModule implements ProtectionModule {
 
     @Override
     public void load() {
-        dataStore = GriefPrevention.instance.dataStore;
+        griefPrevention = GriefPrevention.instance;
+
+        try {
+            Claim.class.getDeclaredMethod("checkPermission", Player.class, ClaimPermission.class, Event.class);
+            useClaimPermission = true;
+        } catch (NoSuchMethodException ignored) {
+            // Very dated GP version, use legacy methods.
+        }
     }
 
     @Override
     public boolean hasPermission(OfflinePlayer p, Location l, Interaction action) {
-        Claim claim = dataStore.getClaimAt(l, true, null);
+        World world = l.getWorld();
+
+        if (world == null || !griefPrevention.claimsEnabledForWorld(world)) {
+            return true;
+        }
+
+        Claim claim = griefPrevention.dataStore.getClaimAt(l, true, null);
 
         if (claim == null) {
             return true;
+        } else if (action == Interaction.ATTACK_PLAYER) {
+            return !griefPrevention.claimIsPvPSafeZone(claim);
         } else if (p.getUniqueId().equals(claim.ownerID)) {
             return true;
-        } else if (!(p instanceof Player)) {
+        }
+
+        if (useClaimPermission) {
+            return checkPermission(claim, p, action);
+        }
+
+        if (!(p instanceof Player)) {
             return false;
         }
 
+        return checkLegacy(claim, (Player) p, action, l);
+    }
+
+    private boolean checkPermission(@Nonnull Claim claim, @Nonnull OfflinePlayer offline, @Nonnull Interaction action) {
+        ClaimPermission permission;
+        if (action == Interaction.INTERACT_BLOCK) {
+            permission = ClaimPermission.Inventory;
+        } else if (action == Interaction.BREAK_BLOCK || action == Interaction.PLACE_BLOCK) {
+            permission = ClaimPermission.Build;
+        } else {
+            permission = ClaimPermission.Access;
+        }
+
+        if (offline instanceof Player) {
+            return claim.checkPermission((Player) offline, permission, null) == null;
+        }
+
+        return claim.checkPermission(offline.getUniqueId(), permission, null) == null;
+    }
+
+    private boolean checkLegacy(@Nonnull Claim claim, @Nonnull Player player, @Nonnull Interaction action, @Nonnull Location location) {
         switch (action) {
             case INTERACT_BLOCK:
-                return claim.allowContainers((Player) p) == null;
-            case ATTACK_PLAYER:
-                return claim.siegeData == null || claim.siegeData.attacker == null;
+                return claim.allowContainers(player) == null;
             case BREAK_BLOCK:
-                return claim.allowBreak((Player) p, l.getBlock().getType()) == null;
+                return claim.allowBreak(player, location.getBlock().getType()) == null;
             case PLACE_BLOCK:
-                return claim.allowBuild((Player) p, l.getBlock().getType()) == null;
+                return claim.allowBuild(player, location.getBlock().getType()) == null;
             default:
-                return claim.allowAccess((Player) p) == null;
+                return claim.allowAccess(player) == null;
         }
     }
 


### PR DESCRIPTION
* Don't construct denial message when it is not used
  * GP constructs messages using claim owner's name, which causes the name to be loaded from disk. GP definitely can do better here (names should be cached), but it shouldn't be constructed at all if not necessary.
* Fix claim owner always being considered able to PVP
* Fix PVP being allowed in claims that are configured to disable it
* Improve future compatibility by not directly referencing siege (GP 17 plans to remove it)
* Update GP dependency to point to new location
* Fix animals being attackable with AccessTrust

Frankly I'm not sure it's worth bothering reflectively checking if the "new" API is available - it was introduced over 2 years ago - but it's simple enough to include legacy support.
This also isn't super accurate to a lot of edge cases (claims modes that require building, etc.) but it was at risk of becoming a lot of unmaintainable spaghetti when I started including that, so I dropped it.