### PR TITLE
Add Bolt protection module

### DIFF
--- a/dough-api/pom.xml
+++ b/dough-api/pom.xml
@@ -432,6 +432,14 @@
             <version>1.13-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
+
+        <!-- Bolt -->
+        <dependency>
+            <groupId>org.popcraft</groupId>
+            <artifactId>bolt-bukkit</artifactId>
+            <version>1.0.580</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/dough-protection/pom.xml
+++ b/dough-protection/pom.xml
@@ -254,6 +254,13 @@
             <scope>provided</scope>
         </dependency>
 
+        <!-- Bolt -->
+        <dependency>
+            <groupId>org.popcraft</groupId>
+            <artifactId>bolt-bukkit</artifactId>
+            <version>1.0.580</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/dough-protection/src/main/java/io/github/bakedlibs/dough/protection/ProtectionManager.java
+++ b/dough-protection/src/main/java/io/github/bakedlibs/dough/protection/ProtectionManager.java
@@ -20,6 +20,7 @@ import io.github.bakedlibs.dough.protection.loggers.CoreProtectLogger;
 import io.github.bakedlibs.dough.protection.loggers.LogBlockLogger;
 import io.github.bakedlibs.dough.protection.modules.BentoBoxProtectionModule;
 import io.github.bakedlibs.dough.protection.modules.BlockLockerProtectionModule;
+import io.github.bakedlibs.dough.protection.modules.BoltProtectionModule;
 import io.github.bakedlibs.dough.protection.modules.ChestProtectProtectionModule;
 import io.github.bakedlibs.dough.protection.modules.FactionsUUIDProtectionModule;
 import io.github.bakedlibs.dough.protection.modules.FunnyGuildsProtectionModule;
@@ -95,6 +96,7 @@ public final class ProtectionManager {
         registerModule(pm, "HuskTowns", huskTowns -> new HuskTownsProtectionModule(huskTowns));
         registerModule(pm, "ShopChest", shopChest -> new ShopChestProtectionModule(shopChest));
         registerModule(pm, "HuskClaims", huskClaims -> new HuskClaimsProtectionModule(huskClaims));
+        registerModule(pm, "Bolt", bolt -> new BoltProtectionModule(bolt));
 
         /*
          * The following Plugins work by utilising one of the above listed

--- a/dough-protection/src/main/java/io/github/bakedlibs/dough/protection/modules/BoltProtectionModule.java
+++ b/dough-protection/src/main/java/io/github/bakedlibs/dough/protection/modules/BoltProtectionModule.java
@@ -1,0 +1,61 @@
+package io.github.bakedlibs.dough.protection.modules;
+
+import io.github.bakedlibs.dough.protection.ActionType;
+import io.github.bakedlibs.dough.protection.Interaction;
+import io.github.bakedlibs.dough.protection.ProtectionModule;
+import org.bukkit.Location;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.plugin.Plugin;
+import org.popcraft.bolt.BoltAPI;
+import org.popcraft.bolt.protection.Protection;
+import org.popcraft.bolt.util.Permission;
+
+import javax.annotation.Nonnull;
+
+public class BoltProtectionModule implements ProtectionModule {
+
+    private BoltAPI bolt;
+    private final Plugin plugin;
+
+    public BoltProtectionModule(@Nonnull Plugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public Plugin getPlugin() {
+        return this.plugin;
+    }
+
+    @Override
+    public void load() {
+        bolt = this.plugin.getServer().getServicesManager().load(BoltAPI.class);
+    }
+
+    @Override
+    public boolean hasPermission(OfflinePlayer p, Location l, Interaction action) {
+        if (action.getType() != ActionType.BLOCK) {
+            return true;
+        }
+
+        String permission = boltPermission(action);
+        if (permission == null) {
+            return true;
+        }
+        Protection protection = this.bolt.findProtection(l.getBlock());
+        return this.bolt.canAccess(protection, p.getUniqueId(), permission);
+    }
+
+    private String boltPermission(Interaction interaction) {
+        switch (interaction) {
+            case BREAK_BLOCK:
+            case ATTACK_PLAYER:
+            case ATTACK_ENTITY:
+                return Permission.DESTROY;
+            case PLACE_BLOCK:
+            case INTERACT_BLOCK:
+            case INTERACT_ENTITY:
+                return Permission.INTERACT;
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
This patch adds Bolt as one of the supported protection modules.

Note that Bolt supports entity protections, however, since Bolt only deals with individual entities, and this API only passes a location, it would make it tricky to look up entities. It is possible to find all entities located around the given location, but it feels like a messy approach.

Closes https://github.com/pop4959/Bolt/issues/138