### PR TITLE
Refactors CustomItemStack to not extend ItemStack

### DIFF
--- a/dough-items/src/main/java/io/github/bakedlibs/dough/items/CustomItemStack.java
+++ b/dough-items/src/main/java/io/github/bakedlibs/dough/items/CustomItemStack.java
@@ -2,163 +2,76 @@ package io.github.bakedlibs.dough.items;
 
 import org.bukkit.Color;
 import org.bukkit.Material;
-import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
-import org.bukkit.inventory.meta.LeatherArmorMeta;
-import org.bukkit.inventory.meta.PotionMeta;
 
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
-import java.util.Arrays;
 import java.util.List;
 import java.util.function.Consumer;
 
-/**
- * Fluent class to apply edits/transformations to an {@link ItemStack} and it's {@link ItemMeta} instance
- * <p>
- * All methods in this class which are not getters mutate this instance.<br>
- * The {@link ItemStack} instance which this class holds on to is never mutated.
- *
- * @see #create()
- * @see #applyTo(ItemStack)
- */
 @ParametersAreNonnullByDefault
-public class CustomItemStack {
+public final class CustomItemStack {
 
-    private final ItemStack itemStack;
-    private Consumer<ItemMeta> metaTransform;
-    private Consumer<ItemStack> stackTransform;
-
-    public CustomItemStack(ItemStack item) {
-        this.itemStack = item.clone();
+    private CustomItemStack() {
+        throw new IllegalStateException("Cannot instantiate CustomItemStack");
     }
 
-    public CustomItemStack(Material type) {
-        this.itemStack = new ItemStack(type);
+    public static ItemStack create(ItemStack itemStack, Consumer<ItemMeta> metaConsumer) {
+        return new ItemStackEditor(itemStack).appendMetaConsumer(metaConsumer).create();
     }
 
-    public CustomItemStack(ItemStack item, Consumer<ItemMeta> meta) {
-        this(item);
-        this.metaTransform = meta;
+    public static ItemStack create(Material material, Consumer<ItemMeta> metaConsumer) {
+        return new ItemStackEditor(material).appendMetaConsumer(metaConsumer).create();
     }
 
-    public CustomItemStack(Material type, Consumer<ItemMeta> meta) {
-        this(new ItemStack(type), meta);
+    public static ItemStack create(ItemStack item, @Nullable String name, String... lore) {
+        return new ItemStackEditor(item)
+                .setDisplayName(name)
+                .setLore(lore)
+                .create();
     }
 
-    public CustomItemStack(ItemStack item, @Nullable String name, String... lore) {
-        this(item);
-        setDisplayName(name).setLore(lore);
+    public static ItemStack create(ItemStack item, Color color, @Nullable String name, String... lore) {
+        return new ItemStackEditor(item)
+                .setColor(color)
+                .setDisplayName(name)
+                .setLore(lore)
+                .create();
     }
 
-    public CustomItemStack(ItemStack item, Color color, @Nullable String name, String... lore) {
-        this(item, name, lore);
-        setColor(color);
+    public static ItemStack create(Material material, @Nullable String name, String... lore) {
+        return create(new ItemStack(material), name, lore);
     }
 
-    public CustomItemStack(Material type, @Nullable String name, String... lore) {
-        this(new ItemStack(type), name, lore);
+    public static ItemStack create(Material type, @Nullable String name, List<String> lore) {
+        return create(new ItemStack(type), name, lore.toArray(String[]::new));
     }
 
-    public CustomItemStack(Material type, @Nullable String name, List<String> lore) {
-        this(new ItemStack(type), name, lore.toArray(new String[lore.size()]));
+
+    public static ItemStack create(ItemStack item, List<String> list) {
+        return create(new ItemStack(item), list.get(0), list.subList(1, list.size()).toArray(String[]::new));
     }
 
-    public CustomItemStack(ItemStack item, List<String> list) {
-        this(item, list.get(0), list.subList(1, list.size()).toArray(new String[0]));
+    public static ItemStack create(Material type, List<String> list) {
+        return create(new ItemStack(type), list);
     }
 
-    public CustomItemStack(Material type, List<String> list) {
-        this(new ItemStack(type), list);
+    public static ItemStack create(ItemStack item, int amount) {
+        return new ItemStackEditor(item).setAmount(amount).create();
     }
 
-    public CustomItemStack(ItemStack item, int amount) {
-        this(item);
-        setAmount(amount);
-    }
-
-    public CustomItemStack(ItemStack item, Material type) {
-        this(item);
-        appendStackConsumer(stack -> stack.setType(type));
-    }
-
-    public CustomItemStack addFlags(ItemFlag... flags) {
-        return appendMetaConsumer(ItemStackUtil.appendItemFlags(flags));
-    }
-
-    public CustomItemStack setCustomModel(int data) {
-        return appendMetaConsumer(ItemStackUtil.editCustomModelData(data));
-    }
-
-    public CustomItemStack setCustomModel(@Nullable Integer data) {
-        return appendMetaConsumer(ItemStackUtil.editCustomModelData(data));
-    }
-
-    public CustomItemStack setAmount(int amount) {
-        return appendStackConsumer(stack -> stack.setAmount(amount));
-    }
-
-    public CustomItemStack setColor(Color color) {
-        return appendMetaConsumer(meta -> {
-            if (meta instanceof LeatherArmorMeta) {
-                ((LeatherArmorMeta) meta).setColor(color);
-            }
-            if (meta instanceof PotionMeta) {
-                ((PotionMeta) meta).setColor(color);
-            }
-        });
-    }
-
-    public CustomItemStack setLore(String... lore) {
-        return setLore(Arrays.asList(lore));
-    }
-
-    public CustomItemStack setLore(List<String> list) {
-        return appendMetaConsumer(ItemStackUtil.editLore(list));
-    }
-
-    public CustomItemStack setDisplayName(@Nullable String name) {
-        return appendMetaConsumer(ItemStackUtil.editDisplayName(name));
-    }
-
-    public CustomItemStack appendMetaConsumer(Consumer<ItemMeta> consumer) {
-        if (this.metaTransform == null) {
-            return setMetaConsumer(consumer);
-        }
-        return setMetaConsumer(this.metaTransform.andThen(consumer));
-    }
-
-    public CustomItemStack setMetaConsumer(Consumer<ItemMeta> consumer) {
-        this.metaTransform = consumer;
-        return this;
-    }
-
-    public CustomItemStack setStackConsumer(Consumer<ItemStack> consumer) {
-        this.stackTransform = consumer;
-        return this;
-    }
-
-    public CustomItemStack appendStackConsumer(Consumer<ItemStack> consumer) {
-        if (this.stackTransform == null) {
-            return setStackConsumer(consumer);
-        }
-        return setStackConsumer(this.stackTransform.andThen(consumer));
-    }
-
-    public ItemStack create() {
-        ItemStack cloned = this.itemStack.clone();
-        applyTo(cloned);
-        return cloned;
-    }
-
-    public void applyTo(ItemStack itemStack) {
-        if (this.stackTransform != null) {
-            this.stackTransform.accept(itemStack);
-        }
-        if (this.metaTransform != null) {
-            ItemStackUtil.editMeta(itemStack, this.metaTransform);
-        }
+    /**
+     * Clones the item stack and sets its type
+     *
+     * @param itemStack The item
+     * @param type      The new type
+     * @return Returns the item with a new type
+     * @deprecated Setting the type via {@link ItemStack#setType(Material)} will not be supported soon.
+     */
+    @Deprecated(forRemoval = true)
+    public static ItemStack create(ItemStack itemStack, Material type) {
+        return new ItemStackEditor(itemStack).appendStackConsumer(item -> item.setType(type)).create();
     }
 
 }

--- a/dough-items/src/main/java/io/github/bakedlibs/dough/items/CustomItemStack.java
+++ b/dough-items/src/main/java/io/github/bakedlibs/dough/items/CustomItemStack.java
@@ -1,10 +1,5 @@
 package io.github.bakedlibs.dough.items;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.function.Consumer;
-
-import org.bukkit.ChatColor;
 import org.bukkit.Color;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemFlag;
@@ -13,90 +8,62 @@ import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.LeatherArmorMeta;
 import org.bukkit.inventory.meta.PotionMeta;
 
-public class CustomItemStack extends ItemStack {
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Consumer;
+
+/**
+ * Fluent class to apply edits/transformations to an {@link ItemStack} and it's {@link ItemMeta} instance
+ * <p>
+ * All methods in this class which are not getters mutate this instance.<br>
+ * The {@link ItemStack} instance which this class holds on to is never mutated.
+ *
+ * @see #create()
+ * @see #applyTo(ItemStack)
+ */
+@ParametersAreNonnullByDefault
+public class CustomItemStack {
+
+    private final ItemStack itemStack;
+    private Consumer<ItemMeta> metaTransform = meta -> {
+    };
+    private Consumer<ItemStack> stackTransform = stack -> {
+    };
 
     public CustomItemStack(ItemStack item) {
-        super(item);
+        this.itemStack = item.clone();
     }
 
     public CustomItemStack(Material type) {
-        super(type);
+        this.itemStack = new ItemStack(type);
     }
 
     public CustomItemStack(ItemStack item, Consumer<ItemMeta> meta) {
-        super(item);
-        ItemMeta im = getItemMeta();
-        meta.accept(im);
-        setItemMeta(im);
+        this(item);
+        this.metaTransform = meta;
     }
 
     public CustomItemStack(Material type, Consumer<ItemMeta> meta) {
         this(new ItemStack(type), meta);
-
     }
 
-    public CustomItemStack(ItemStack item, String name, String... lore) {
-        this(item, im -> {
-            if (name != null) {
-                im.setDisplayName(ChatColor.translateAlternateColorCodes('&', name));
-            }
-
-            if (lore.length > 0) {
-                List<String> lines = new ArrayList<>();
-
-                for (String line : lore) {
-                    lines.add(ChatColor.translateAlternateColorCodes('&', line));
-                }
-                im.setLore(lines);
-            }
-        });
+    public CustomItemStack(ItemStack item, @Nullable String name, String... lore) {
+        this(item);
+        setDisplayName(name).setLore(lore);
     }
 
-    public CustomItemStack(ItemStack item, Color color, String name, String... lore) {
-        this(item, im -> {
-            if (name != null) {
-                im.setDisplayName(ChatColor.translateAlternateColorCodes('&', name));
-            }
-
-            if (lore.length > 0) {
-                List<String> lines = new ArrayList<>();
-
-                for (String line : lore) {
-                    lines.add(ChatColor.translateAlternateColorCodes('&', line));
-                }
-                im.setLore(lines);
-            }
-
-            if (im instanceof LeatherArmorMeta) {
-                ((LeatherArmorMeta) im).setColor(color);
-            }
-            if (im instanceof PotionMeta) {
-                ((PotionMeta) im).setColor(color);
-            }
-        });
+    public CustomItemStack(ItemStack item, Color color, @Nullable String name, String... lore) {
+        this(item, name, lore);
+        setColor(color);
     }
 
-    public CustomItemStack addFlags(ItemFlag... flags) {
-        ItemMeta im = getItemMeta();
-        im.addItemFlags(flags);
-        setItemMeta(im);
-
-        return this;
-    }
-
-    public CustomItemStack setCustomModel(int data) {
-        ItemMeta im = getItemMeta();
-        im.setCustomModelData(data == 0 ? null : data);
-        setItemMeta(im);
-
-        return this;
-    }
-
-    public CustomItemStack(Material type, String name, String... lore) {
+    public CustomItemStack(Material type, @Nullable String name, String... lore) {
         this(new ItemStack(type), name, lore);
     }
 
-    public CustomItemStack(Material type, String name, List<String> lore) {
+    public CustomItemStack(Material type, @Nullable String name, List<String> lore) {
         this(new ItemStack(type), name, lore.toArray(new String[lore.size()]));
     }
 
@@ -109,13 +76,89 @@ public class CustomItemStack extends ItemStack {
     }
 
     public CustomItemStack(ItemStack item, int amount) {
-        super(item);
+        this(item);
         setAmount(amount);
     }
 
     public CustomItemStack(ItemStack item, Material type) {
-        super(item);
-        setType(type);
+        this(item);
+        appendStackConsumer(stack -> stack.setType(type));
+    }
+
+    public CustomItemStack addFlags(ItemFlag... flags) {
+        return appendMetaConsumer(ItemStackUtil.appendItemFlags(flags));
+    }
+
+    public CustomItemStack setCustomModel(int data) {
+        return appendMetaConsumer(ItemStackUtil.editCustomModelData(data));
+    }
+
+    public CustomItemStack setCustomModel(@Nullable Integer data) {
+        return appendMetaConsumer(ItemStackUtil.editCustomModelData(data));
+    }
+
+    public CustomItemStack setAmount(int amount) {
+        return appendStackConsumer(stack -> stack.setAmount(amount));
+    }
+
+    public CustomItemStack setColor(Color color) {
+        return appendMetaConsumer(meta -> {
+            if (meta instanceof LeatherArmorMeta) {
+                ((LeatherArmorMeta) meta).setColor(color);
+            }
+            if (meta instanceof PotionMeta) {
+                ((PotionMeta) meta).setColor(color);
+            }
+        });
+    }
+
+    public CustomItemStack setLore(String... lore) {
+        return setLore(Arrays.asList(lore));
+    }
+
+    public CustomItemStack setLore(List<String> list) {
+        return appendMetaConsumer(ItemStackUtil.editLore(list));
+    }
+
+    public CustomItemStack setDisplayName(@Nullable String name) {
+        return appendMetaConsumer(ItemStackUtil.editDisplayName(name));
+    }
+
+    public CustomItemStack appendMetaConsumer(Consumer<ItemMeta> consumer) {
+        return setMetaConsumer(this.metaTransform.andThen(consumer));
+    }
+
+    public CustomItemStack setMetaConsumer(Consumer<ItemMeta> consumer) {
+        this.metaTransform = consumer;
+        return this;
+    }
+
+    public CustomItemStack setStackConsumer(Consumer<ItemStack> consumer) {
+        this.stackTransform = consumer;
+        return this;
+    }
+
+    public CustomItemStack appendStackConsumer(Consumer<ItemStack> consumer) {
+        return setStackConsumer(this.stackTransform.andThen(consumer));
+    }
+
+    public Consumer<ItemMeta> getMetaTransform() {
+        return this.metaTransform;
+    }
+
+    public Consumer<ItemStack> getStackTransform() {
+        return this.stackTransform;
+    }
+
+    public ItemStack create() {
+        ItemStack cloned = this.itemStack.clone();
+        applyTo(cloned);
+        return cloned;
+    }
+
+    public void applyTo(ItemStack itemStack) {
+        this.stackTransform.accept(itemStack);
+        ItemStackUtil.editMeta(itemStack, this.metaTransform);
     }
 
 }

--- a/dough-items/src/main/java/io/github/bakedlibs/dough/items/CustomItemStack.java
+++ b/dough-items/src/main/java/io/github/bakedlibs/dough/items/CustomItemStack.java
@@ -32,14 +32,6 @@ public final class CustomItemStack {
                 .create();
     }
 
-    public static ItemStack create(ItemStack item, Color color, @Nullable String name, String... lore) {
-        return new ItemStackEditor(item)
-                .setColor(color)
-                .setDisplayName(name)
-                .setLore(lore)
-                .create();
-    }
-
     public static ItemStack create(Material material, @Nullable String name, String... lore) {
         return create(new ItemStack(material), name, lore);
     }

--- a/dough-items/src/main/java/io/github/bakedlibs/dough/items/CustomItemStack.java
+++ b/dough-items/src/main/java/io/github/bakedlibs/dough/items/CustomItemStack.java
@@ -27,10 +27,8 @@ import java.util.function.Consumer;
 public class CustomItemStack {
 
     private final ItemStack itemStack;
-    private Consumer<ItemMeta> metaTransform = meta -> {
-    };
-    private Consumer<ItemStack> stackTransform = stack -> {
-    };
+    private Consumer<ItemMeta> metaTransform;
+    private Consumer<ItemStack> stackTransform;
 
     public CustomItemStack(ItemStack item) {
         this.itemStack = item.clone();
@@ -125,6 +123,9 @@ public class CustomItemStack {
     }
 
     public CustomItemStack appendMetaConsumer(Consumer<ItemMeta> consumer) {
+        if (this.metaTransform == null) {
+            return setMetaConsumer(consumer);
+        }
         return setMetaConsumer(this.metaTransform.andThen(consumer));
     }
 
@@ -139,15 +140,10 @@ public class CustomItemStack {
     }
 
     public CustomItemStack appendStackConsumer(Consumer<ItemStack> consumer) {
+        if (this.stackTransform == null) {
+            return setStackConsumer(consumer);
+        }
         return setStackConsumer(this.stackTransform.andThen(consumer));
-    }
-
-    public Consumer<ItemMeta> getMetaTransform() {
-        return this.metaTransform;
-    }
-
-    public Consumer<ItemStack> getStackTransform() {
-        return this.stackTransform;
     }
 
     public ItemStack create() {
@@ -157,8 +153,12 @@ public class CustomItemStack {
     }
 
     public void applyTo(ItemStack itemStack) {
-        this.stackTransform.accept(itemStack);
-        ItemStackUtil.editMeta(itemStack, this.metaTransform);
+        if (this.stackTransform != null) {
+            this.stackTransform.accept(itemStack);
+        }
+        if (this.metaTransform != null) {
+            ItemStackUtil.editMeta(itemStack, this.metaTransform);
+        }
     }
 
 }

--- a/dough-items/src/main/java/io/github/bakedlibs/dough/items/CustomItemStack.java
+++ b/dough-items/src/main/java/io/github/bakedlibs/dough/items/CustomItemStack.java
@@ -1,6 +1,5 @@
 package io.github.bakedlibs.dough.items;
 
-import org.bukkit.Color;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
@@ -18,11 +17,11 @@ public final class CustomItemStack {
     }
 
     public static ItemStack create(ItemStack itemStack, Consumer<ItemMeta> metaConsumer) {
-        return new ItemStackEditor(itemStack).appendMetaConsumer(metaConsumer).create();
+        return new ItemStackEditor(itemStack).andMetaConsumer(metaConsumer).create();
     }
 
     public static ItemStack create(Material material, Consumer<ItemMeta> metaConsumer) {
-        return new ItemStackEditor(material).appendMetaConsumer(metaConsumer).create();
+        return new ItemStackEditor(material).andMetaConsumer(metaConsumer).create();
     }
 
     public static ItemStack create(ItemStack item, @Nullable String name, String... lore) {
@@ -63,7 +62,7 @@ public final class CustomItemStack {
      */
     @Deprecated(forRemoval = true)
     public static ItemStack create(ItemStack itemStack, Material type) {
-        return new ItemStackEditor(itemStack).appendStackConsumer(item -> item.setType(type)).create();
+        return new ItemStackEditor(itemStack).andStackConsumer(item -> item.setType(type)).create();
     }
 
 }

--- a/dough-items/src/main/java/io/github/bakedlibs/dough/items/ItemStackEditor.java
+++ b/dough-items/src/main/java/io/github/bakedlibs/dough/items/ItemStackEditor.java
@@ -1,0 +1,119 @@
+package io.github.bakedlibs.dough.items;
+
+import org.bukkit.Color;
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemFlag;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.inventory.meta.LeatherArmorMeta;
+import org.bukkit.inventory.meta.PotionMeta;
+
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Consumer;
+
+/**
+ * Fluent class to apply edits/transformations to an {@link ItemStack} and it's {@link ItemMeta} instance
+ * <p>
+ * All methods in this class which are not getters mutate this instance.<br>
+ * The {@link ItemStack} instance which this class holds on to is never mutated.
+ *
+ * @see #create()
+ * @see #applyTo(ItemStack)
+ */
+@ParametersAreNonnullByDefault
+public class ItemStackEditor {
+
+    private final ItemStack itemStack;
+    private Consumer<ItemMeta> metaTransform = null;
+    private Consumer<ItemStack> stackTransform = null;
+
+    public ItemStackEditor(ItemStack item) {
+        this.itemStack = item.clone();
+    }
+
+    public ItemStackEditor(Material type) {
+        this.itemStack = new ItemStack(type);
+    }
+
+    public ItemStackEditor addFlags(ItemFlag... flags) {
+        return appendMetaConsumer(ItemStackUtil.appendItemFlags(flags));
+    }
+
+    public ItemStackEditor setCustomModel(int data) {
+        return appendMetaConsumer(ItemStackUtil.editCustomModelData(data));
+    }
+
+    public ItemStackEditor setCustomModel(@Nullable Integer data) {
+        return appendMetaConsumer(ItemStackUtil.editCustomModelData(data));
+    }
+
+    public ItemStackEditor setAmount(int amount) {
+        return appendStackConsumer(stack -> stack.setAmount(amount));
+    }
+
+    public ItemStackEditor setColor(Color color) {
+        return appendMetaConsumer(meta -> {
+            if (meta instanceof LeatherArmorMeta) {
+                ((LeatherArmorMeta) meta).setColor(color);
+            }
+            if (meta instanceof PotionMeta) {
+                ((PotionMeta) meta).setColor(color);
+            }
+        });
+    }
+
+    public ItemStackEditor setLore(String... lore) {
+        return setLore(Arrays.asList(lore));
+    }
+
+    public ItemStackEditor setLore(List<String> list) {
+        return appendMetaConsumer(ItemStackUtil.editLore(list));
+    }
+
+    public ItemStackEditor setDisplayName(@Nullable String name) {
+        return appendMetaConsumer(ItemStackUtil.editDisplayName(name));
+    }
+
+    public ItemStackEditor appendMetaConsumer(Consumer<ItemMeta> consumer) {
+        if (this.metaTransform == null) {
+            return setMetaConsumer(consumer);
+        }
+        return setMetaConsumer(this.metaTransform.andThen(consumer));
+    }
+
+    public ItemStackEditor setMetaConsumer(@Nullable Consumer<ItemMeta> consumer) {
+        this.metaTransform = consumer;
+        return this;
+    }
+
+    public ItemStackEditor setStackConsumer(@Nullable Consumer<ItemStack> consumer) {
+        this.stackTransform = consumer;
+        return this;
+    }
+
+    public ItemStackEditor appendStackConsumer(Consumer<ItemStack> consumer) {
+        if (this.stackTransform == null) {
+            return setStackConsumer(consumer);
+        }
+        return setStackConsumer(this.stackTransform.andThen(consumer));
+    }
+
+    public ItemStack create() {
+        ItemStack cloned = this.itemStack.clone();
+        applyTo(cloned);
+        return cloned;
+    }
+
+    public void applyTo(ItemStack itemStack) {
+        if (this.stackTransform != null) {
+            this.stackTransform.accept(itemStack);
+        }
+        if (this.metaTransform != null) {
+            ItemStackUtil.editMeta(itemStack, this.metaTransform);
+        }
+    }
+
+}

--- a/dough-items/src/main/java/io/github/bakedlibs/dough/items/ItemStackUtil.java
+++ b/dough-items/src/main/java/io/github/bakedlibs/dough/items/ItemStackUtil.java
@@ -1,0 +1,145 @@
+package io.github.bakedlibs.dough.items;
+
+import io.papermc.lib.PaperLib;
+import org.bukkit.ChatColor;
+import org.bukkit.Color;
+import org.bukkit.inventory.ItemFlag;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.inventory.meta.LeatherArmorMeta;
+import org.bukkit.inventory.meta.PotionMeta;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Consumer;
+
+/**
+ * Utility class to edit the {@link ItemMeta} on an {@link ItemStack}
+ *
+ * @author md5sha256
+ */
+@ParametersAreNonnullByDefault
+public final class ItemStackUtil {
+
+    private ItemStackUtil() {
+        throw new IllegalStateException("Static utility class cannot be instantiated");
+    }
+
+    /**
+     * Curries a {@link Consumer} which sets the display name to the given {@link String}.
+     * The string will have its color codes translated.
+     *
+     * @param name The name to set
+     * @return Returns a {@link Consumer}
+     */
+    public static Consumer<ItemMeta> editDisplayName(@Nullable String name) {
+        return (meta) -> {
+            if (name != null) {
+                meta.setDisplayName(ChatColor.translateAlternateColorCodes('&', name));
+            }
+        };
+    }
+
+    /**
+     * Curries a {@link Consumer} which sets the lore to the given {@link String}s.
+     * The strings will have their color codes translated.
+     *
+     * @param lore The lore to set
+     * @return Returns a {@link Consumer}
+     */
+    public static Consumer<ItemMeta> editLore(@Nonnull String... lore) {
+        return editLore(Arrays.asList(lore));
+    }
+
+
+    /**
+     * Curries a {@link Consumer} which sets the lore to the given {@link String}s.
+     * The strings will have their color codes translated.
+     *
+     * @param lore The lore to set
+     * @return Returns a {@link Consumer}
+     */
+    public static Consumer<ItemMeta> editLore(@Nonnull List<String> lore) {
+        return (meta) -> {
+            if (lore.isEmpty()) {
+                meta.lore(Collections.emptyList());
+                return;
+            }
+            List<String> newLore = new ArrayList<>(lore);
+            newLore.replaceAll(line -> ChatColor.translateAlternateColorCodes('&', line));
+            meta.setLore(newLore);
+        };
+    }
+
+    /**
+     * Curries a {@link Consumer} which calls {@link PotionMeta#setColor(Color)} or {@link LeatherArmorMeta#setColor(Color)}
+     * if the {@link ItemMeta} is an instance of either.
+     *
+     * @param color The color to set
+     * @return Returns a {@link Consumer}
+     */
+    public static Consumer<ItemMeta> editColor(@Nonnull Color color) {
+        return (meta) -> {
+            if (meta instanceof LeatherArmorMeta) {
+                ((LeatherArmorMeta) meta).setColor(color);
+            }
+            if (meta instanceof PotionMeta) {
+                ((PotionMeta) meta).setColor(color);
+            }
+        };
+    }
+
+    /**
+     * Curries a {@link Consumer} which sets the custom model data to the given integer
+     *
+     * @param data The custom model data to set
+     * @return Returns a {@link Consumer}
+     */
+    public static Consumer<ItemMeta> editCustomModelData(@Nullable Integer data) {
+        return (meta) -> meta.setCustomModelData(data);
+    }
+
+    /**
+     * Curries a {@link Consumer} which sets the custom model data to the given integer
+     *
+     * @param data The custom model data to set
+     * @return Returns a {@link Consumer}
+     */
+    public static Consumer<ItemMeta> editCustomModelData(int data) {
+        return (meta) -> meta.setCustomModelData(data == 0 ? null : data);
+    }
+
+    /**
+     * Curries a {@link Consumer} which adds the given {@link ItemFlag}s
+     * @param flags The item flags
+     * @return Returns a {@link Consumer}
+     */
+    public static Consumer<ItemMeta> appendItemFlags(ItemFlag... flags) {
+        return (meta) -> meta.addItemFlags(flags);
+    }
+
+    /**
+     * Applies an edit to the {@link ItemMeta} of the given {@link ItemStack}, returning whether
+     * the changes were successfully applied
+     *
+     * @param itemStack The item
+     * @param consumer  The edits to apply
+     * @return {@link ItemStack#editMeta(Consumer)} if on paper, {@link ItemStack#setItemMeta(ItemMeta)} otherwise
+     */
+    public static boolean editMeta(ItemStack itemStack, Consumer<ItemMeta> consumer) {
+        if (PaperLib.isPaper()) {
+            return itemStack.editMeta(consumer);
+        } else {
+            ItemMeta itemMeta = itemStack.getItemMeta();
+            if (itemMeta != null) {
+                consumer.accept(itemMeta);
+            }
+            return itemStack.setItemMeta(itemMeta);
+        }
+    }
+}

--- a/dough-items/src/main/java/io/github/bakedlibs/dough/items/ItemStackUtil.java
+++ b/dough-items/src/main/java/io/github/bakedlibs/dough/items/ItemStackUtil.java
@@ -67,7 +67,7 @@ public final class ItemStackUtil {
     public static Consumer<ItemMeta> editLore(@Nonnull List<String> lore) {
         return (meta) -> {
             if (lore.isEmpty()) {
-                meta.lore(Collections.emptyList());
+                meta.setLore(Collections.emptyList());
                 return;
             }
             List<String> newLore = new ArrayList<>(lore);

--- a/dough-items/src/test/java/io/github/bakedlibs/dough/items/ConsumerInvocationCounter.java
+++ b/dough-items/src/test/java/io/github/bakedlibs/dough/items/ConsumerInvocationCounter.java
@@ -1,0 +1,36 @@
+package io.github.bakedlibs.dough.items;
+
+import java.util.function.Consumer;
+
+public class ConsumerInvocationCounter<T> implements Consumer<T> {
+
+    private final Consumer<T> nested;
+    private int invokeCount = 0;
+
+    public ConsumerInvocationCounter() {
+        this(x -> {
+        });
+    }
+
+    public ConsumerInvocationCounter(Consumer<T> consumer) {
+        this.nested = consumer;
+    }
+
+    @Override
+    public void accept(T t) {
+        this.nested.accept(t);
+        this.invokeCount += 1;
+    }
+
+    public boolean wasInvoked() {
+        return this.invokeCount > 0;
+    }
+
+    public int getInvokeCount() {
+        return this.invokeCount;
+    }
+
+    public void resetInvokeCount() {
+        this.invokeCount = 0;
+    }
+}

--- a/dough-items/src/test/java/io/github/bakedlibs/dough/items/TestCustomItemStack.java
+++ b/dough-items/src/test/java/io/github/bakedlibs/dough/items/TestCustomItemStack.java
@@ -29,6 +29,16 @@ import java.util.stream.Stream;
 
 class TestCustomItemStack {
 
+    @BeforeAll
+    public static void init() {
+        MockBukkit.mock();
+    }
+
+    @AfterAll
+    public static void teardown() {
+        MockBukkit.unmock();
+    }
+
     private static Stream<Material> itemMaterials() {
         return Arrays.stream(Material.values())
                 .filter(Predicate.not(Material::isLegacy))
@@ -111,16 +121,6 @@ class TestCustomItemStack {
                 lore -> CustomItemStack.create(itemStack, null, lore),
                 lore -> CustomItemStack.create(itemStack, Color.AQUA, null, lore)
         );
-    }
-
-    @BeforeAll
-    public static void init() {
-        MockBukkit.mock();
-    }
-
-    @AfterAll
-    public static void teardown() {
-        MockBukkit.unmock();
     }
 
     @Test

--- a/dough-items/src/test/java/io/github/bakedlibs/dough/items/TestCustomItemStack.java
+++ b/dough-items/src/test/java/io/github/bakedlibs/dough/items/TestCustomItemStack.java
@@ -51,41 +51,39 @@ class TestCustomItemStack {
         return itemMaterials().filter(material -> getItemMeta(material) instanceof LeatherArmorMeta);
     }
 
-    private static Stream<Function<ItemStack, CustomItemStack>> itemStackConstructors() {
+    private static Stream<Function<ItemStack, ItemStack>> itemStackConstructors() {
         return Stream.of(
-                CustomItemStack::new,
-                item -> new CustomItemStack(item, "test"),
-                item -> new CustomItemStack(item, "test", "test"),
-                item -> new CustomItemStack(item, List.of("test", "test")),
-                item -> new CustomItemStack(item, Color.AQUA, "test", "test"),
-                item -> new CustomItemStack(item, meta -> {
+                item -> CustomItemStack.create(item, "test"),
+                item -> CustomItemStack.create(item, "test", "test"),
+                item -> CustomItemStack.create(item, List.of("test", "test")),
+                item -> CustomItemStack.create(item, Color.AQUA, "test", "test"),
+                item -> CustomItemStack.create(item, meta -> {
                 }),
-                item -> new CustomItemStack(item, item.getAmount())
+                item -> CustomItemStack.create(item, item.getAmount())
         );
     }
 
-    private static Stream<Function<String, CustomItemStack>> displayNameConstructors() {
+    private static Stream<Function<String, ItemStack>> displayNameConstructors() {
         Material material = Material.STICK;
         ItemStack itemStack = new ItemStack(material);
         return Stream.of(
-                name -> new CustomItemStack(material, name),
-                name -> new CustomItemStack(itemStack, name),
-                name -> new CustomItemStack(material, name, "test"),
-                name -> new CustomItemStack(itemStack, name, "test"),
-                name -> new CustomItemStack(material, name, List.of("test")),
-                name -> new CustomItemStack(itemStack, Color.AQUA, name, "test")
+                name -> CustomItemStack.create(material, name),
+                name -> CustomItemStack.create(itemStack, name),
+                name -> CustomItemStack.create(material, name, "test"),
+                name -> CustomItemStack.create(itemStack, name, "test"),
+                name -> CustomItemStack.create(material, name, List.of("test")),
+                name -> CustomItemStack.create(itemStack, Color.AQUA, name, "test")
         );
     }
 
-    private static Stream<Function<Material, CustomItemStack>> materialConstructors() {
+    private static Stream<Function<Material, ItemStack>> materialConstructors() {
         return Stream.of(
-                CustomItemStack::new,
-                material -> new CustomItemStack(material, "test"),
-                material -> new CustomItemStack(material, "test", "test"),
-                material -> new CustomItemStack(material, "test", List.of("test")),
-                material -> new CustomItemStack(material, List.of("test", "test")),
-                material -> new CustomItemStack(material, meta -> {}),
-                material -> new CustomItemStack(new ItemStack(Material.AIR), material)
+                material -> CustomItemStack.create(material, "test"),
+                material -> CustomItemStack.create(material, "test", "test"),
+                material -> CustomItemStack.create(material, "test", List.of("test")),
+                material -> CustomItemStack.create(material, List.of("test", "test")),
+                material -> CustomItemStack.create(material, meta -> {}),
+                material -> CustomItemStack.create(new ItemStack(Material.AIR), material)
         );
     }
 
@@ -96,22 +94,22 @@ class TestCustomItemStack {
         return Collections.unmodifiableList(ret);
     }
 
-    private static Stream<Function<List<String>, CustomItemStack>> loreListConstructors() {
+    private static Stream<Function<List<String>, ItemStack>> loreListConstructors() {
         Material material = Material.STICK;
         ItemStack itemStack = new ItemStack(material);
         return Stream.of(
-                lore -> new CustomItemStack(material, null, lore),
-                lore -> new CustomItemStack(itemStack, insertNull(lore))
+                lore -> CustomItemStack.create(material, null, lore),
+                lore -> CustomItemStack.create(itemStack, insertNull(lore))
         );
     }
 
-    private static Stream<Function<String[], CustomItemStack>> loreVarArgsConstructors() {
+    private static Stream<Function<String[], ItemStack>> loreVarArgsConstructors() {
         Material material = Material.STICK;
         ItemStack itemStack = new ItemStack(material);
         return Stream.of(
-                lore -> new CustomItemStack(material, null, lore),
-                lore -> new CustomItemStack(itemStack, null, lore),
-                lore -> new CustomItemStack(itemStack, Color.AQUA, null, lore)
+                lore -> CustomItemStack.create(material, null, lore),
+                lore -> CustomItemStack.create(itemStack, null, lore),
+                lore -> CustomItemStack.create(itemStack, Color.AQUA, null, lore)
         );
     }
 
@@ -127,169 +125,69 @@ class TestCustomItemStack {
 
     @Test
     void testMaterialIsChanged() {
-        Material actual = new CustomItemStack(new ItemStack(Material.AIR), Material.STICK)
-                .create().getType();
+        Material actual = CustomItemStack.create(new ItemStack(Material.AIR), Material.STICK).getType();
         Assertions.assertEquals(Material.STICK, actual);
     }
 
     @ParameterizedTest
     @MethodSource("materialConstructors")
-    void testConstructorMaterialIsChanged(Function<Material, CustomItemStack> constructor) {
-        Material actual = constructor.apply(Material.STICK).create().getType();
+    void testConstructorMaterialIsChanged(Function<Material, ItemStack> constructor) {
+        Material actual = constructor.apply(Material.STICK).getType();
         Assertions.assertEquals(Material.STICK, actual);
     }
 
     @ParameterizedTest
-    @MethodSource("itemMaterials")
-    void testCanCreateCustomItemStack(Material material) {
-        Assertions.assertDoesNotThrow(() -> new CustomItemStack(material));
-    }
-
-    @Test
-    void testDefaultConstructorsCreateEquivalentItem() {
-        ItemStack expected = new ItemStack(Material.AIR);
-        CustomItemStack customItemStack = new CustomItemStack(expected);
-        CustomItemStack customMaterial = new CustomItemStack(Material.AIR);
-        Assertions.assertEquals(expected, customItemStack.create());
-        Assertions.assertEquals(expected, customMaterial.create());
-    }
-
-    @Test
-    void testCreateAppliesToClone() {
-        ItemStack original = new ItemStack(Material.STICK);
-        CustomItemStack customItemStack = new CustomItemStack(original);
-        original.setAmount(2);
-        Assertions.assertNotEquals(original, customItemStack.create());
-    }
-
-    @Test
-    void testApplyTo() {
-        ItemStack itemStack = new ItemStack(Material.STICK);
-        ItemStack target = new ItemStack(itemStack);
-        new CustomItemStack(itemStack)
-                .setAmount(2)
-                .applyTo(target);
-        Assertions.assertEquals(2, target.getAmount());
-    }
-
-    @ParameterizedTest
     @MethodSource("itemStackConstructors")
-    void testConstructorClonesInput(Function<ItemStack, CustomItemStack> constructor) {
+    void testConstructorClonesInput(Function<ItemStack, ItemStack> constructor) {
         ItemStack itemStack = new ItemStack(Material.STICK);
         ItemStack expected = new ItemStack(itemStack);
         constructor.apply(itemStack);
         Assertions.assertEquals(expected, itemStack);
     }
 
-    @Test
-    void testNullDisplayNameAllowed() {
-        ItemMeta meta = new CustomItemStack(Material.STICK)
-                .setDisplayName(null)
-                .create().getItemMeta();
+    @ParameterizedTest
+    @MethodSource("displayNameConstructors")
+    void testConstructorNullDisplayNameAllowed(Function<String, ItemStack> constructor) {
+        ItemMeta meta = constructor.apply(null).getItemMeta();
         Assertions.assertNotNull(meta);
         Assertions.assertFalse(meta.hasDisplayName());
     }
 
     @ParameterizedTest
     @MethodSource("displayNameConstructors")
-    void testConstructorNullDisplayNameAllowed(Function<String, CustomItemStack> constructor) {
-        ItemMeta meta = constructor.apply(null).create().getItemMeta();
-        Assertions.assertNotNull(meta);
-        Assertions.assertFalse(meta.hasDisplayName());
-    }
-
-    @Test
-    void testDisplayNameChangedAndSanitized() {
+    void testConstructorDisplayNameChangedAndSanitized(Function<String, ItemStack> constructor) {
         String name = "&btest";
         String expectedName = ChatColor.translateAlternateColorCodes('&', name);
-        ItemMeta meta = new CustomItemStack(Material.STICK)
-                .setDisplayName(name)
-                .create().getItemMeta();
+        ItemMeta meta = constructor.apply(name).getItemMeta();
         Assertions.assertNotNull(meta);
         Assertions.assertEquals(expectedName, meta.getDisplayName());
-    }
-
-    @ParameterizedTest
-    @MethodSource("displayNameConstructors")
-    void testConstructorDisplayNameChangedAndSanitized(Function<String, CustomItemStack> constructor) {
-        String name = "&btest";
-        String expectedName = ChatColor.translateAlternateColorCodes('&', name);
-        ItemMeta meta = constructor.apply(name).create().getItemMeta();
-        Assertions.assertNotNull(meta);
-        Assertions.assertEquals(expectedName, meta.getDisplayName());
-    }
-
-    @Test
-    void testLoreAsListChangedAndSanitized() {
-        List<String> lore = List.of("&btest");
-        List<String> expected = lore.stream()
-                .map(s -> ChatColor.translateAlternateColorCodes('&', s)).collect(Collectors.toList());
-        ItemMeta meta = new CustomItemStack(Material.STICK)
-                .setLore(lore)
-                .create().getItemMeta();
-        Assertions.assertIterableEquals(expected, meta.getLore());
     }
 
     @ParameterizedTest
     @MethodSource("loreListConstructors")
-    void testConstructorLoreAsListChangedAndSanitized(Function<List<String>, CustomItemStack> constructor) {
+    void testConstructorLoreAsListChangedAndSanitized(Function<List<String>, ItemStack> constructor) {
         List<String> lore = List.of("&btest");
         List<String> expected = lore.stream()
                 .map(s -> ChatColor.translateAlternateColorCodes('&', s)).collect(Collectors.toList());
-        ItemMeta meta = constructor.apply(lore).create().getItemMeta();
-        Assertions.assertIterableEquals(expected, meta.getLore());
-    }
-
-    @Test
-    void testLoreAsVarargsChangedAndSanitized() {
-        List<String> lore = List.of("&btest");
-        List<String> expected = lore.stream()
-                .map(s -> ChatColor.translateAlternateColorCodes('&', s)).collect(Collectors.toList());
-        ItemMeta meta = new CustomItemStack(Material.STICK)
-                .setLore("&btest")
-                .create().getItemMeta();
+        ItemMeta meta = constructor.apply(lore).getItemMeta();
         Assertions.assertIterableEquals(expected, meta.getLore());
     }
 
     @ParameterizedTest
     @MethodSource("loreVarArgsConstructors")
-    void testConstructorLoreAsVarargsChangedAndSanitized(Function<String[], CustomItemStack> constructor) {
+    void testConstructorLoreAsVarargsChangedAndSanitized(Function<String[], ItemStack> constructor) {
         List<String> lore = List.of("&btest");
         List<String> expected = lore.stream()
                 .map(s -> ChatColor.translateAlternateColorCodes('&', s)).collect(Collectors.toList());
-        ItemMeta meta = constructor.apply(new String[]{"&btest"}).create().getItemMeta();
+        ItemMeta meta = constructor.apply(new String[]{"&btest"}).getItemMeta();
         Assertions.assertIterableEquals(expected, meta.getLore());
-    }
-
-    @Test
-    void testColorUnchanged() {
-        ItemStack expected = new ItemStack(Material.STICK);
-        // set the color on an invalid item will still cause
-        // an explcit set of the item meta
-        expected.setItemMeta(expected.getItemMeta());
-        ItemStack actual = new CustomItemStack(expected)
-                .setColor(Color.AQUA)
-                .create();
-        Assertions.assertEquals(expected, actual);
-    }
-
-    @ParameterizedTest
-    @MethodSource("potionMaterials")
-    void testColorChangedForPotionMeta(Material material) {
-        ItemMeta meta = new CustomItemStack(material)
-                .setColor(Color.AQUA)
-                .create()
-                .getItemMeta();
-        Assertions.assertInstanceOf(PotionMeta.class, meta);
-        PotionMeta potionMeta = (PotionMeta) meta;
-        Assertions.assertEquals(Color.AQUA, potionMeta.getColor());
     }
 
     @ParameterizedTest
     @MethodSource("potionMaterials")
     void testConstructorColorChangedForPotionMeta(Material material) {
-        ItemMeta meta = new CustomItemStack(new ItemStack(material), Color.AQUA, "test", "test")
-                .create().getItemMeta();
+        ItemMeta meta = CustomItemStack.create(new ItemStack(material), Color.AQUA, "test", "test")
+                .getItemMeta();
         Assertions.assertInstanceOf(PotionMeta.class, meta);
         PotionMeta potionMeta = (PotionMeta) meta;
         Assertions.assertEquals(Color.AQUA, potionMeta.getColor());
@@ -297,64 +195,12 @@ class TestCustomItemStack {
 
     @ParameterizedTest
     @MethodSource("leatherArmorMaterials")
-    void testColorChangedForLeatherMeta(Material material) {
-        ItemMeta meta = new CustomItemStack(material)
-                .setColor(Color.AQUA)
-                .create()
+    void testConstructorColorChangedForLeatherMeta(Material material) {
+        ItemMeta meta = CustomItemStack.create(new ItemStack(material), Color.AQUA, "test", "test")
                 .getItemMeta();
         Assertions.assertInstanceOf(LeatherArmorMeta.class, meta);
         LeatherArmorMeta armorMeta = (LeatherArmorMeta) meta;
         Assertions.assertEquals(Color.AQUA, armorMeta.getColor());
-    }
-
-    @ParameterizedTest
-    @MethodSource("leatherArmorMaterials")
-    void testConstructorColorChangedForLeatherMeta(Material material) {
-        ItemMeta meta = new CustomItemStack(new ItemStack(material), Color.AQUA, "test", "test")
-                .create().getItemMeta();
-        Assertions.assertInstanceOf(LeatherArmorMeta.class, meta);
-        LeatherArmorMeta armorMeta = (LeatherArmorMeta) meta;
-        Assertions.assertEquals(Color.AQUA, armorMeta.getColor());
-    }
-
-    @Test
-    void testCustomModelDataChanged() {
-        ItemMeta itemMeta = new CustomItemStack(Material.STICK)
-                .setCustomModel(1)
-                .create().getItemMeta();
-        Assertions.assertEquals(1, itemMeta.getCustomModelData());
-    }
-
-    @Test
-    void testCustomModelDataNullIfZero() {
-        ItemStack itemStack = new ItemStack(Material.STICK);
-        itemStack.editMeta(meta -> meta.setCustomModelData(1));
-        Assertions.assertNotNull(itemStack.getItemMeta());
-        Assertions.assertTrue(itemStack.getItemMeta().hasCustomModelData());
-        ItemMeta itemMeta = new CustomItemStack(itemStack)
-                .setCustomModel(0)
-                .create().getItemMeta();
-        Assertions.assertFalse(itemMeta.hasCustomModelData());
-    }
-
-    @Test
-    void testCustomModelDataNullIfNull() {
-        ItemStack itemStack = new ItemStack(Material.STICK);
-        itemStack.editMeta(meta -> meta.setCustomModelData(1));
-        Assertions.assertNotNull(itemStack.getItemMeta());
-        Assertions.assertTrue(itemStack.getItemMeta().hasCustomModelData());
-        ItemMeta itemMeta = new CustomItemStack(itemStack)
-                .setCustomModel(null)
-                .create().getItemMeta();
-        Assertions.assertFalse(itemMeta.hasCustomModelData());
-    }
-
-    @Test
-    void testItemFlagsChanged() {
-        ItemMeta meta = new CustomItemStack(Material.STICK)
-                .addFlags(ItemFlag.HIDE_ENCHANTS)
-                .create().getItemMeta();
-        Assertions.assertTrue(meta.getItemFlags().contains(ItemFlag.HIDE_ENCHANTS));
     }
 
 }

--- a/dough-items/src/test/java/io/github/bakedlibs/dough/items/TestCustomItemStack.java
+++ b/dough-items/src/test/java/io/github/bakedlibs/dough/items/TestCustomItemStack.java
@@ -4,13 +4,9 @@ import be.seeseemelk.mockbukkit.MockBukkit;
 import be.seeseemelk.mockbukkit.UnimplementedOperationException;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
-import org.bukkit.Color;
 import org.bukkit.Material;
-import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
-import org.bukkit.inventory.meta.LeatherArmorMeta;
-import org.bukkit.inventory.meta.PotionMeta;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
@@ -53,20 +49,11 @@ class TestCustomItemStack {
         }
     }
 
-    private static Stream<Material> potionMaterials() {
-        return itemMaterials().filter(material -> getItemMeta(material) instanceof PotionMeta);
-    }
-
-    private static Stream<Material> leatherArmorMaterials() {
-        return itemMaterials().filter(material -> getItemMeta(material) instanceof LeatherArmorMeta);
-    }
-
     private static Stream<Function<ItemStack, ItemStack>> itemStackConstructors() {
         return Stream.of(
                 item -> CustomItemStack.create(item, "test"),
                 item -> CustomItemStack.create(item, "test", "test"),
                 item -> CustomItemStack.create(item, List.of("test", "test")),
-                item -> CustomItemStack.create(item, Color.AQUA, "test", "test"),
                 item -> CustomItemStack.create(item, meta -> {
                 }),
                 item -> CustomItemStack.create(item, item.getAmount())
@@ -81,8 +68,7 @@ class TestCustomItemStack {
                 name -> CustomItemStack.create(itemStack, name),
                 name -> CustomItemStack.create(material, name, "test"),
                 name -> CustomItemStack.create(itemStack, name, "test"),
-                name -> CustomItemStack.create(material, name, List.of("test")),
-                name -> CustomItemStack.create(itemStack, Color.AQUA, name, "test")
+                name -> CustomItemStack.create(material, name, List.of("test"))
         );
     }
 
@@ -118,8 +104,7 @@ class TestCustomItemStack {
         ItemStack itemStack = new ItemStack(material);
         return Stream.of(
                 lore -> CustomItemStack.create(material, null, lore),
-                lore -> CustomItemStack.create(itemStack, null, lore),
-                lore -> CustomItemStack.create(itemStack, Color.AQUA, null, lore)
+                lore -> CustomItemStack.create(itemStack, null, lore)
         );
     }
 
@@ -181,26 +166,6 @@ class TestCustomItemStack {
                 .map(s -> ChatColor.translateAlternateColorCodes('&', s)).collect(Collectors.toList());
         ItemMeta meta = constructor.apply(new String[]{"&btest"}).getItemMeta();
         Assertions.assertIterableEquals(expected, meta.getLore());
-    }
-
-    @ParameterizedTest
-    @MethodSource("potionMaterials")
-    void testConstructorColorChangedForPotionMeta(Material material) {
-        ItemMeta meta = CustomItemStack.create(new ItemStack(material), Color.AQUA, "test", "test")
-                .getItemMeta();
-        Assertions.assertInstanceOf(PotionMeta.class, meta);
-        PotionMeta potionMeta = (PotionMeta) meta;
-        Assertions.assertEquals(Color.AQUA, potionMeta.getColor());
-    }
-
-    @ParameterizedTest
-    @MethodSource("leatherArmorMaterials")
-    void testConstructorColorChangedForLeatherMeta(Material material) {
-        ItemMeta meta = CustomItemStack.create(new ItemStack(material), Color.AQUA, "test", "test")
-                .getItemMeta();
-        Assertions.assertInstanceOf(LeatherArmorMeta.class, meta);
-        LeatherArmorMeta armorMeta = (LeatherArmorMeta) meta;
-        Assertions.assertEquals(Color.AQUA, armorMeta.getColor());
     }
 
 }

--- a/dough-items/src/test/java/io/github/bakedlibs/dough/items/TestCustomItemStack.java
+++ b/dough-items/src/test/java/io/github/bakedlibs/dough/items/TestCustomItemStack.java
@@ -1,0 +1,360 @@
+package io.github.bakedlibs.dough.items;
+
+import be.seeseemelk.mockbukkit.MockBukkit;
+import be.seeseemelk.mockbukkit.UnimplementedOperationException;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Color;
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemFlag;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.inventory.meta.LeatherArmorMeta;
+import org.bukkit.inventory.meta.PotionMeta;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+class TestCustomItemStack {
+
+    private static Stream<Material> itemMaterials() {
+        return Arrays.stream(Material.values())
+                .filter(Predicate.not(Material::isLegacy))
+                .filter(Material::isItem);
+    }
+
+    private static ItemMeta getItemMeta(Material material) {
+        try {
+            return Bukkit.getItemFactory().getItemMeta(material);
+        } catch (UnimplementedOperationException ex) {
+            return null;
+        }
+    }
+
+    private static Stream<Material> potionMaterials() {
+        return itemMaterials().filter(material -> getItemMeta(material) instanceof PotionMeta);
+    }
+
+    private static Stream<Material> leatherArmorMaterials() {
+        return itemMaterials().filter(material -> getItemMeta(material) instanceof LeatherArmorMeta);
+    }
+
+    private static Stream<Function<ItemStack, CustomItemStack>> itemStackConstructors() {
+        return Stream.of(
+                CustomItemStack::new,
+                item -> new CustomItemStack(item, "test"),
+                item -> new CustomItemStack(item, "test", "test"),
+                item -> new CustomItemStack(item, List.of("test", "test")),
+                item -> new CustomItemStack(item, Color.AQUA, "test", "test"),
+                item -> new CustomItemStack(item, meta -> {
+                }),
+                item -> new CustomItemStack(item, item.getAmount())
+        );
+    }
+
+    private static Stream<Function<String, CustomItemStack>> displayNameConstructors() {
+        Material material = Material.STICK;
+        ItemStack itemStack = new ItemStack(material);
+        return Stream.of(
+                name -> new CustomItemStack(material, name),
+                name -> new CustomItemStack(itemStack, name),
+                name -> new CustomItemStack(material, name, "test"),
+                name -> new CustomItemStack(itemStack, name, "test"),
+                name -> new CustomItemStack(material, name, List.of("test")),
+                name -> new CustomItemStack(itemStack, Color.AQUA, name, "test")
+        );
+    }
+
+    private static Stream<Function<Material, CustomItemStack>> materialConstructors() {
+        return Stream.of(
+                CustomItemStack::new,
+                material -> new CustomItemStack(material, "test"),
+                material -> new CustomItemStack(material, "test", "test"),
+                material -> new CustomItemStack(material, "test", List.of("test")),
+                material -> new CustomItemStack(material, List.of("test", "test")),
+                material -> new CustomItemStack(material, meta -> {}),
+                material -> new CustomItemStack(new ItemStack(Material.AIR), material)
+        );
+    }
+
+    private static <T> List<T> insertNull(List<T> list) {
+        List<T> ret = new ArrayList<>();
+        ret.add(null);
+        ret.addAll(list);
+        return Collections.unmodifiableList(ret);
+    }
+
+    private static Stream<Function<List<String>, CustomItemStack>> loreListConstructors() {
+        Material material = Material.STICK;
+        ItemStack itemStack = new ItemStack(material);
+        return Stream.of(
+                lore -> new CustomItemStack(material, null, lore),
+                lore -> new CustomItemStack(itemStack, insertNull(lore))
+        );
+    }
+
+    private static Stream<Function<String[], CustomItemStack>> loreVarArgsConstructors() {
+        Material material = Material.STICK;
+        ItemStack itemStack = new ItemStack(material);
+        return Stream.of(
+                lore -> new CustomItemStack(material, null, lore),
+                lore -> new CustomItemStack(itemStack, null, lore),
+                lore -> new CustomItemStack(itemStack, Color.AQUA, null, lore)
+        );
+    }
+
+    @BeforeAll
+    public static void init() {
+        MockBukkit.mock();
+    }
+
+    @AfterAll
+    public static void teardown() {
+        MockBukkit.unmock();
+    }
+
+    @Test
+    void testMaterialIsChanged() {
+        Material actual = new CustomItemStack(new ItemStack(Material.AIR), Material.STICK)
+                .create().getType();
+        Assertions.assertEquals(Material.STICK, actual);
+    }
+
+    @ParameterizedTest
+    @MethodSource("materialConstructors")
+    void testConstructorMaterialIsChanged(Function<Material, CustomItemStack> constructor) {
+        Material actual = constructor.apply(Material.STICK).create().getType();
+        Assertions.assertEquals(Material.STICK, actual);
+    }
+
+    @ParameterizedTest
+    @MethodSource("itemMaterials")
+    void testCanCreateCustomItemStack(Material material) {
+        Assertions.assertDoesNotThrow(() -> new CustomItemStack(material));
+    }
+
+    @Test
+    void testDefaultConstructorsCreateEquivalentItem() {
+        ItemStack expected = new ItemStack(Material.AIR);
+        CustomItemStack customItemStack = new CustomItemStack(expected);
+        CustomItemStack customMaterial = new CustomItemStack(Material.AIR);
+        Assertions.assertEquals(expected, customItemStack.create());
+        Assertions.assertEquals(expected, customMaterial.create());
+    }
+
+    @Test
+    void testCreateAppliesToClone() {
+        ItemStack original = new ItemStack(Material.STICK);
+        CustomItemStack customItemStack = new CustomItemStack(original);
+        original.setAmount(2);
+        Assertions.assertNotEquals(original, customItemStack.create());
+    }
+
+    @Test
+    void testApplyTo() {
+        ItemStack itemStack = new ItemStack(Material.STICK);
+        ItemStack target = new ItemStack(itemStack);
+        new CustomItemStack(itemStack)
+                .setAmount(2)
+                .applyTo(target);
+        Assertions.assertEquals(2, target.getAmount());
+    }
+
+    @ParameterizedTest
+    @MethodSource("itemStackConstructors")
+    void testConstructorClonesInput(Function<ItemStack, CustomItemStack> constructor) {
+        ItemStack itemStack = new ItemStack(Material.STICK);
+        ItemStack expected = new ItemStack(itemStack);
+        constructor.apply(itemStack);
+        Assertions.assertEquals(expected, itemStack);
+    }
+
+    @Test
+    void testNullDisplayNameAllowed() {
+        ItemMeta meta = new CustomItemStack(Material.STICK)
+                .setDisplayName(null)
+                .create().getItemMeta();
+        Assertions.assertNotNull(meta);
+        Assertions.assertFalse(meta.hasDisplayName());
+    }
+
+    @ParameterizedTest
+    @MethodSource("displayNameConstructors")
+    void testConstructorNullDisplayNameAllowed(Function<String, CustomItemStack> constructor) {
+        ItemMeta meta = constructor.apply(null).create().getItemMeta();
+        Assertions.assertNotNull(meta);
+        Assertions.assertFalse(meta.hasDisplayName());
+    }
+
+    @Test
+    void testDisplayNameChangedAndSanitized() {
+        String name = "&btest";
+        String expectedName = ChatColor.translateAlternateColorCodes('&', name);
+        ItemMeta meta = new CustomItemStack(Material.STICK)
+                .setDisplayName(name)
+                .create().getItemMeta();
+        Assertions.assertNotNull(meta);
+        Assertions.assertEquals(expectedName, meta.getDisplayName());
+    }
+
+    @ParameterizedTest
+    @MethodSource("displayNameConstructors")
+    void testConstructorDisplayNameChangedAndSanitized(Function<String, CustomItemStack> constructor) {
+        String name = "&btest";
+        String expectedName = ChatColor.translateAlternateColorCodes('&', name);
+        ItemMeta meta = constructor.apply(name).create().getItemMeta();
+        Assertions.assertNotNull(meta);
+        Assertions.assertEquals(expectedName, meta.getDisplayName());
+    }
+
+    @Test
+    void testLoreAsListChangedAndSanitized() {
+        List<String> lore = List.of("&btest");
+        List<String> expected = lore.stream()
+                .map(s -> ChatColor.translateAlternateColorCodes('&', s)).collect(Collectors.toList());
+        ItemMeta meta = new CustomItemStack(Material.STICK)
+                .setLore(lore)
+                .create().getItemMeta();
+        Assertions.assertIterableEquals(expected, meta.getLore());
+    }
+
+    @ParameterizedTest
+    @MethodSource("loreListConstructors")
+    void testConstructorLoreAsListChangedAndSanitized(Function<List<String>, CustomItemStack> constructor) {
+        List<String> lore = List.of("&btest");
+        List<String> expected = lore.stream()
+                .map(s -> ChatColor.translateAlternateColorCodes('&', s)).collect(Collectors.toList());
+        ItemMeta meta = constructor.apply(lore).create().getItemMeta();
+        Assertions.assertIterableEquals(expected, meta.getLore());
+    }
+
+    @Test
+    void testLoreAsVarargsChangedAndSanitized() {
+        List<String> lore = List.of("&btest");
+        List<String> expected = lore.stream()
+                .map(s -> ChatColor.translateAlternateColorCodes('&', s)).collect(Collectors.toList());
+        ItemMeta meta = new CustomItemStack(Material.STICK)
+                .setLore("&btest")
+                .create().getItemMeta();
+        Assertions.assertIterableEquals(expected, meta.getLore());
+    }
+
+    @ParameterizedTest
+    @MethodSource("loreVarArgsConstructors")
+    void testConstructorLoreAsVarargsChangedAndSanitized(Function<String[], CustomItemStack> constructor) {
+        List<String> lore = List.of("&btest");
+        List<String> expected = lore.stream()
+                .map(s -> ChatColor.translateAlternateColorCodes('&', s)).collect(Collectors.toList());
+        ItemMeta meta = constructor.apply(new String[]{"&btest"}).create().getItemMeta();
+        Assertions.assertIterableEquals(expected, meta.getLore());
+    }
+
+    @Test
+    void testColorUnchanged() {
+        ItemStack expected = new ItemStack(Material.STICK);
+        // set the color on an invalid item will still cause
+        // an explcit set of the item meta
+        expected.setItemMeta(expected.getItemMeta());
+        ItemStack actual = new CustomItemStack(expected)
+                .setColor(Color.AQUA)
+                .create();
+        Assertions.assertEquals(expected, actual);
+    }
+
+    @ParameterizedTest
+    @MethodSource("potionMaterials")
+    void testColorChangedForPotionMeta(Material material) {
+        ItemMeta meta = new CustomItemStack(material)
+                .setColor(Color.AQUA)
+                .create()
+                .getItemMeta();
+        Assertions.assertInstanceOf(PotionMeta.class, meta);
+        PotionMeta potionMeta = (PotionMeta) meta;
+        Assertions.assertEquals(Color.AQUA, potionMeta.getColor());
+    }
+
+    @ParameterizedTest
+    @MethodSource("potionMaterials")
+    void testConstructorColorChangedForPotionMeta(Material material) {
+        ItemMeta meta = new CustomItemStack(new ItemStack(material), Color.AQUA, "test", "test")
+                .create().getItemMeta();
+        Assertions.assertInstanceOf(PotionMeta.class, meta);
+        PotionMeta potionMeta = (PotionMeta) meta;
+        Assertions.assertEquals(Color.AQUA, potionMeta.getColor());
+    }
+
+    @ParameterizedTest
+    @MethodSource("leatherArmorMaterials")
+    void testColorChangedForLeatherMeta(Material material) {
+        ItemMeta meta = new CustomItemStack(material)
+                .setColor(Color.AQUA)
+                .create()
+                .getItemMeta();
+        Assertions.assertInstanceOf(LeatherArmorMeta.class, meta);
+        LeatherArmorMeta armorMeta = (LeatherArmorMeta) meta;
+        Assertions.assertEquals(Color.AQUA, armorMeta.getColor());
+    }
+
+    @ParameterizedTest
+    @MethodSource("leatherArmorMaterials")
+    void testConstructorColorChangedForLeatherMeta(Material material) {
+        ItemMeta meta = new CustomItemStack(new ItemStack(material), Color.AQUA, "test", "test")
+                .create().getItemMeta();
+        Assertions.assertInstanceOf(LeatherArmorMeta.class, meta);
+        LeatherArmorMeta armorMeta = (LeatherArmorMeta) meta;
+        Assertions.assertEquals(Color.AQUA, armorMeta.getColor());
+    }
+
+    @Test
+    void testCustomModelDataChanged() {
+        ItemMeta itemMeta = new CustomItemStack(Material.STICK)
+                .setCustomModel(1)
+                .create().getItemMeta();
+        Assertions.assertEquals(1, itemMeta.getCustomModelData());
+    }
+
+    @Test
+    void testCustomModelDataNullIfZero() {
+        ItemStack itemStack = new ItemStack(Material.STICK);
+        itemStack.editMeta(meta -> meta.setCustomModelData(1));
+        Assertions.assertNotNull(itemStack.getItemMeta());
+        Assertions.assertTrue(itemStack.getItemMeta().hasCustomModelData());
+        ItemMeta itemMeta = new CustomItemStack(itemStack)
+                .setCustomModel(0)
+                .create().getItemMeta();
+        Assertions.assertFalse(itemMeta.hasCustomModelData());
+    }
+
+    @Test
+    void testCustomModelDataNullIfNull() {
+        ItemStack itemStack = new ItemStack(Material.STICK);
+        itemStack.editMeta(meta -> meta.setCustomModelData(1));
+        Assertions.assertNotNull(itemStack.getItemMeta());
+        Assertions.assertTrue(itemStack.getItemMeta().hasCustomModelData());
+        ItemMeta itemMeta = new CustomItemStack(itemStack)
+                .setCustomModel(null)
+                .create().getItemMeta();
+        Assertions.assertFalse(itemMeta.hasCustomModelData());
+    }
+
+    @Test
+    void testItemFlagsChanged() {
+        ItemMeta meta = new CustomItemStack(Material.STICK)
+                .addFlags(ItemFlag.HIDE_ENCHANTS)
+                .create().getItemMeta();
+        Assertions.assertTrue(meta.getItemFlags().contains(ItemFlag.HIDE_ENCHANTS));
+    }
+
+}

--- a/dough-items/src/test/java/io/github/bakedlibs/dough/items/TestItemStackEditor.java
+++ b/dough-items/src/test/java/io/github/bakedlibs/dough/items/TestItemStackEditor.java
@@ -26,6 +26,16 @@ import java.util.stream.Stream;
 
 class TestItemStackEditor {
 
+    @BeforeAll
+    public static void init() {
+        MockBukkit.mock();
+    }
+
+    @AfterAll
+    public static void teardown() {
+        MockBukkit.unmock();
+    }
+
     private static Stream<Material> itemMaterials() {
         return Arrays.stream(Material.values())
                 .filter(Predicate.not(Material::isLegacy))
@@ -46,16 +56,6 @@ class TestItemStackEditor {
 
     private static Stream<Material> leatherArmorMaterials() {
         return itemMaterials().filter(material -> getItemMeta(material) instanceof LeatherArmorMeta);
-    }
-
-    @BeforeAll
-    public static void init() {
-        MockBukkit.mock();
-    }
-
-    @AfterAll
-    public static void teardown() {
-        MockBukkit.unmock();
     }
 
     @ParameterizedTest

--- a/dough-items/src/test/java/io/github/bakedlibs/dough/items/TestItemStackEditor.java
+++ b/dough-items/src/test/java/io/github/bakedlibs/dough/items/TestItemStackEditor.java
@@ -222,8 +222,7 @@ class TestItemStackEditor {
     @Test
     void testItemMetaNotSetIfMetaTransformIsNull() {
         ItemStack expected = new ItemStack(Material.AIR);
-        ItemStackEditor editor = new ItemStackEditor(Material.AIR);
-        editor.setMetaConsumer(null);
+        ItemStackEditor editor = new ItemStackEditor(Material.AIR).withMetaConsumer(null);
         Assertions.assertEquals(expected, editor.create());
     }
 
@@ -231,8 +230,7 @@ class TestItemStackEditor {
     void testItemMetaSetIfMetaTransformIsNotNull() {
         ItemStack expected = new ItemStack(Material.AIR);
         expected.setItemMeta(expected.getItemMeta());
-        ItemStackEditor editor = new ItemStackEditor(Material.AIR);
-        editor.setMetaConsumer(meta -> {});
+        ItemStackEditor editor = new ItemStackEditor(Material.AIR).withMetaConsumer(meta -> {});
         Assertions.assertEquals(expected, editor.create());
     }
 

--- a/dough-items/src/test/java/io/github/bakedlibs/dough/items/TestItemStackEditor.java
+++ b/dough-items/src/test/java/io/github/bakedlibs/dough/items/TestItemStackEditor.java
@@ -1,0 +1,239 @@
+package io.github.bakedlibs.dough.items;
+
+import be.seeseemelk.mockbukkit.MockBukkit;
+import be.seeseemelk.mockbukkit.UnimplementedOperationException;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Color;
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemFlag;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.inventory.meta.LeatherArmorMeta;
+import org.bukkit.inventory.meta.PotionMeta;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+class TestItemStackEditor {
+
+    private static Stream<Material> itemMaterials() {
+        return Arrays.stream(Material.values())
+                .filter(Predicate.not(Material::isLegacy))
+                .filter(Material::isItem);
+    }
+
+    private static ItemMeta getItemMeta(Material material) {
+        try {
+            return Bukkit.getItemFactory().getItemMeta(material);
+        } catch (UnimplementedOperationException ex) {
+            return null;
+        }
+    }
+
+    private static Stream<Material> potionMaterials() {
+        return itemMaterials().filter(material -> getItemMeta(material) instanceof PotionMeta);
+    }
+
+    private static Stream<Material> leatherArmorMaterials() {
+        return itemMaterials().filter(material -> getItemMeta(material) instanceof LeatherArmorMeta);
+    }
+
+    @BeforeAll
+    public static void init() {
+        MockBukkit.mock();
+    }
+
+    @AfterAll
+    public static void teardown() {
+        MockBukkit.unmock();
+    }
+
+    @ParameterizedTest
+    @MethodSource("itemMaterials")
+    void testCanCreateItemStackEditor(Material material) {
+        Assertions.assertDoesNotThrow(() -> new ItemStackEditor(material));
+        Assertions.assertDoesNotThrow(() -> new ItemStackEditor(new ItemStack(material)));
+    }
+
+    @Test
+    void testDefaultConstructorsCreateEquivalentItem() {
+        ItemStack expected = new ItemStack(Material.AIR);
+        ItemStackEditor editorItem = new ItemStackEditor(expected);
+        ItemStackEditor editorMaterial = new ItemStackEditor(Material.AIR);
+        Assertions.assertEquals(expected, editorItem.create());
+        Assertions.assertEquals(expected, editorMaterial.create());
+    }
+
+    @Test
+    void testCreateAppliesToClone() {
+        ItemStack original = new ItemStack(Material.STICK);
+        ItemStackEditor customItemStack = new ItemStackEditor(original);
+        original.setAmount(2);
+        Assertions.assertNotEquals(original, customItemStack.create());
+    }
+
+    @Test
+    void testApplyTo() {
+        ItemStack itemStack = new ItemStack(Material.STICK);
+        ItemStack target = new ItemStack(itemStack);
+        new ItemStackEditor(itemStack)
+                .setAmount(2)
+                .applyTo(target);
+        Assertions.assertEquals(2, target.getAmount());
+    }
+
+    @Test
+    void testConstructorClonesInput() {
+        ItemStack itemStack = new ItemStack(Material.STICK);
+        ItemStack expected = new ItemStack(itemStack);
+        ItemStackEditor editor = new ItemStackEditor(itemStack);
+        itemStack.setAmount(2);
+        Assertions.assertEquals(expected, editor.create());
+    }
+
+    @Test
+    void testNullDisplayNameAllowed() {
+        ItemMeta meta = new ItemStackEditor(Material.STICK)
+                .setDisplayName(null)
+                .create().getItemMeta();
+        Assertions.assertNotNull(meta);
+        Assertions.assertFalse(meta.hasDisplayName());
+    }
+
+    @Test
+    void testDisplayNameChangedAndSanitized() {
+        String name = "&btest";
+        String expectedName = ChatColor.translateAlternateColorCodes('&', name);
+        ItemMeta meta = new ItemStackEditor(Material.STICK)
+                .setDisplayName(name)
+                .create().getItemMeta();
+        Assertions.assertNotNull(meta);
+        Assertions.assertEquals(expectedName, meta.getDisplayName());
+    }
+
+    @Test
+    void testLoreAsListChangedAndSanitized() {
+        List<String> lore = List.of("&btest");
+        List<String> expected = lore.stream()
+                .map(s -> ChatColor.translateAlternateColorCodes('&', s)).collect(Collectors.toList());
+        ItemMeta meta = new ItemStackEditor(Material.STICK)
+                .setLore(lore)
+                .create().getItemMeta();
+        Assertions.assertIterableEquals(expected, meta.getLore());
+    }
+
+    @Test
+    void testLoreAsVarargsChangedAndSanitized() {
+        List<String> lore = List.of("&btest");
+        List<String> expected = lore.stream()
+                .map(s -> ChatColor.translateAlternateColorCodes('&', s)).collect(Collectors.toList());
+        ItemMeta meta = new ItemStackEditor(Material.STICK)
+                .setLore("&btest")
+                .create().getItemMeta();
+        Assertions.assertIterableEquals(expected, meta.getLore());
+    }
+
+    @Test
+    void testColorUnchanged() {
+        ItemStack expected = new ItemStack(Material.STICK);
+        // set the color on an invalid item will still cause
+        // an explicit set of the item meta
+        expected.setItemMeta(expected.getItemMeta());
+        ItemStack actual = new ItemStackEditor(expected)
+                .setColor(Color.AQUA)
+                .create();
+        Assertions.assertEquals(expected, actual);
+    }
+
+    @ParameterizedTest
+    @MethodSource("potionMaterials")
+    void testColorChangedForPotionMeta(Material material) {
+        ItemMeta meta = new ItemStackEditor(material)
+                .setColor(Color.AQUA)
+                .create()
+                .getItemMeta();
+        Assertions.assertInstanceOf(PotionMeta.class, meta);
+        PotionMeta potionMeta = (PotionMeta) meta;
+        Assertions.assertEquals(Color.AQUA, potionMeta.getColor());
+    }
+
+    @ParameterizedTest
+    @MethodSource("leatherArmorMaterials")
+    void testColorChangedForLeatherMeta(Material material) {
+        ItemMeta meta = new ItemStackEditor(material)
+                .setColor(Color.AQUA)
+                .create()
+                .getItemMeta();
+        Assertions.assertInstanceOf(LeatherArmorMeta.class, meta);
+        LeatherArmorMeta armorMeta = (LeatherArmorMeta) meta;
+        Assertions.assertEquals(Color.AQUA, armorMeta.getColor());
+    }
+
+    @Test
+    void testCustomModelDataChanged() {
+        ItemMeta itemMeta = new ItemStackEditor(Material.STICK)
+                .setCustomModel(1)
+                .create().getItemMeta();
+        Assertions.assertEquals(1, itemMeta.getCustomModelData());
+    }
+
+    @Test
+    void testCustomModelDataNullIfZero() {
+        ItemStack itemStack = new ItemStack(Material.STICK);
+        itemStack.editMeta(meta -> meta.setCustomModelData(1));
+        Assertions.assertNotNull(itemStack.getItemMeta());
+        Assertions.assertTrue(itemStack.getItemMeta().hasCustomModelData());
+        ItemMeta itemMeta = new ItemStackEditor(itemStack)
+                .setCustomModel(0)
+                .create().getItemMeta();
+        Assertions.assertFalse(itemMeta.hasCustomModelData());
+    }
+
+    @Test
+    void testCustomModelDataNullIfNull() {
+        ItemStack itemStack = new ItemStack(Material.STICK);
+        itemStack.editMeta(meta -> meta.setCustomModelData(1));
+        Assertions.assertNotNull(itemStack.getItemMeta());
+        Assertions.assertTrue(itemStack.getItemMeta().hasCustomModelData());
+        ItemMeta itemMeta = new ItemStackEditor(itemStack)
+                .setCustomModel(null)
+                .create().getItemMeta();
+        Assertions.assertFalse(itemMeta.hasCustomModelData());
+    }
+
+    @Test
+    void testItemFlagsChanged() {
+        ItemMeta meta = new ItemStackEditor(Material.STICK)
+                .addFlags(ItemFlag.HIDE_ENCHANTS)
+                .create().getItemMeta();
+        Assertions.assertTrue(meta.getItemFlags().contains(ItemFlag.HIDE_ENCHANTS));
+    }
+
+    @Test
+    void testItemMetaNotSetIfMetaTransformIsNull() {
+        ItemStack expected = new ItemStack(Material.AIR);
+        ItemStackEditor editor = new ItemStackEditor(Material.AIR);
+        editor.setMetaConsumer(null);
+        Assertions.assertEquals(expected, editor.create());
+    }
+
+    @Test
+    void testItemMetaSetIfMetaTransformIsNotNull() {
+        ItemStack expected = new ItemStack(Material.AIR);
+        expected.setItemMeta(expected.getItemMeta());
+        ItemStackEditor editor = new ItemStackEditor(Material.AIR);
+        editor.setMetaConsumer(meta -> {});
+        Assertions.assertEquals(expected, editor.create());
+    }
+
+}

--- a/dough-items/src/test/java/io/github/bakedlibs/dough/items/TestItemStackUtil.java
+++ b/dough-items/src/test/java/io/github/bakedlibs/dough/items/TestItemStackUtil.java
@@ -59,7 +59,8 @@ class TestItemStackUtil {
     void testLoreAsListChangedAndSanitized() {
         List<String> lore = List.of("&btest");
         List<String> expected = lore.stream()
-                .map(s -> ChatColor.translateAlternateColorCodes('&', s)).collect(Collectors.toList());
+                .map(s -> ChatColor.translateAlternateColorCodes('&', s))
+                .collect(Collectors.toList());
         ItemMeta meta = new ItemMetaMock();
         ItemStackUtil.editLore(lore).accept(meta);
         Assertions.assertIterableEquals(expected, meta.getLore());

--- a/dough-items/src/test/java/io/github/bakedlibs/dough/items/TestItemStackUtil.java
+++ b/dough-items/src/test/java/io/github/bakedlibs/dough/items/TestItemStackUtil.java
@@ -1,0 +1,141 @@
+package io.github.bakedlibs.dough.items;
+
+import be.seeseemelk.mockbukkit.MockBukkit;
+import be.seeseemelk.mockbukkit.inventory.meta.ItemMetaMock;
+import be.seeseemelk.mockbukkit.inventory.meta.LeatherArmorMetaMock;
+import be.seeseemelk.mockbukkit.inventory.meta.PotionMetaMock;
+import org.bukkit.ChatColor;
+import org.bukkit.Color;
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemFlag;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.inventory.meta.LeatherArmorMeta;
+import org.bukkit.inventory.meta.PotionMeta;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+class TestItemStackUtil {
+
+    private static Stream<Material> itemMaterials() {
+        return Arrays.stream(Material.values())
+                .filter(Predicate.not(Material::isLegacy))
+                .filter(Material::isItem);
+    }
+
+    @BeforeAll
+    public static void init() {
+        MockBukkit.mock();
+    }
+
+    @AfterAll
+    public static void teardown() {
+        MockBukkit.unmock();
+    }
+
+    @ParameterizedTest
+    @MethodSource("itemMaterials")
+    void testConsumerIsInvokedOnceIfMetaIsNotNull(Material material) {
+        ItemStack itemStack = new ItemStack(material);
+        ItemMeta meta = itemStack.getItemMeta();
+        ConsumerInvocationCounter<ItemMeta> counter = new ConsumerInvocationCounter<>();
+        ItemStackUtil.editMeta(itemStack, counter);
+        if (meta == null) {
+            Assertions.assertFalse(counter.wasInvoked());
+        } else {
+            Assertions.assertTrue(counter.wasInvoked());
+            Assertions.assertEquals(1, counter.getInvokeCount());
+        }
+    }
+
+    @Test
+    void testDisplayNameChangedAndSanitized() {
+        String name = "&btest";
+        String expected = ChatColor.translateAlternateColorCodes('&', name);
+        ItemMeta meta = new ItemMetaMock();
+        ItemStackUtil.editDisplayName(name).accept(meta);
+        Assertions.assertEquals(expected, meta.getDisplayName());
+    }
+
+    @Test
+    void testLoreAsListChangedAndSanitized() {
+        List<String> lore = List.of("&btest");
+        List<String> expected = lore.stream()
+                .map(s -> ChatColor.translateAlternateColorCodes('&', s)).collect(Collectors.toList());
+        ItemMeta meta = new ItemMetaMock();
+        ItemStackUtil.editLore(lore).accept(meta);
+        Assertions.assertIterableEquals(expected, meta.getLore());
+    }
+
+    @Test
+    void testLoreAsVarargsChangedAndSanitized() {
+        List<String> expected = List.of(ChatColor.translateAlternateColorCodes('&', "&btest"));
+        ItemMeta meta = new ItemMetaMock();
+        ItemStackUtil.editLore("&btest").accept(meta);
+        Assertions.assertIterableEquals(expected, meta.getLore());
+    }
+
+    @Test
+    void testColorUnchanged() {
+        ItemMeta original = new ItemMetaMock();
+        ItemMeta unchanged = new ItemMetaMock();
+        ItemStackUtil.editColor(Color.AQUA).accept(unchanged);
+        Assertions.assertEquals(original, unchanged);
+    }
+
+    @Test
+    void testColorChangedForPotionMeta() {
+        PotionMeta meta = new PotionMetaMock();
+        ItemStackUtil.editColor(Color.AQUA).accept(meta);
+        Assertions.assertEquals(Color.AQUA, meta.getColor());
+    }
+
+    @Test
+    void testColorChangedForLeatherMeta() {
+        LeatherArmorMeta meta = new LeatherArmorMetaMock();
+        ItemStackUtil.editColor(Color.AQUA).accept(meta);
+        Assertions.assertEquals(Color.AQUA, meta.getColor());
+    }
+
+    @Test
+    void testCustomModelDataChanged() {
+        ItemMeta itemMeta = new ItemMetaMock();
+        ItemStackUtil.editCustomModelData(1).accept(itemMeta);
+        Assertions.assertEquals(1, itemMeta.getCustomModelData());
+    }
+
+    @Test
+    void testCustomModelDataNullIfZero() {
+        ItemMeta meta = new ItemMetaMock();
+        meta.setCustomModelData(1);
+        ItemStackUtil.editCustomModelData(0).accept(meta);
+        Assertions.assertFalse(meta.hasCustomModelData());
+    }
+
+    @Test
+    void testCustomModelDataNullIfNull() {
+        ItemMeta meta = new ItemMetaMock();
+        meta.setCustomModelData(1);
+        ItemStackUtil.editCustomModelData(null).accept(meta);
+        Assertions.assertFalse(meta.hasCustomModelData());
+    }
+
+    @Test
+    void testItemFlagsChanged() {
+        ItemMeta meta = new ItemMetaMock();
+        Assertions.assertFalse(meta.getItemFlags().contains(ItemFlag.HIDE_ENCHANTS));
+        ItemStackUtil.appendItemFlags(ItemFlag.HIDE_ENCHANTS).accept(meta);
+        Assertions.assertTrue(meta.getItemFlags().contains(ItemFlag.HIDE_ENCHANTS));
+    }
+
+}

--- a/dough-items/src/test/java/io/github/bakedlibs/dough/items/TestItemStackUtil.java
+++ b/dough-items/src/test/java/io/github/bakedlibs/dough/items/TestItemStackUtil.java
@@ -4,9 +4,11 @@ import be.seeseemelk.mockbukkit.MockBukkit;
 import be.seeseemelk.mockbukkit.inventory.meta.ItemMetaMock;
 import be.seeseemelk.mockbukkit.inventory.meta.LeatherArmorMetaMock;
 import be.seeseemelk.mockbukkit.inventory.meta.PotionMetaMock;
+import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Color;
 import org.bukkit.Material;
+import org.bukkit.inventory.ItemFactory;
 import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
@@ -17,21 +19,12 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
-import java.util.Arrays;
 import java.util.List;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 class TestItemStackUtil {
-
-    private static Stream<Material> itemMaterials() {
-        return Arrays.stream(Material.values())
-                .filter(Predicate.not(Material::isLegacy))
-                .filter(Material::isItem);
-    }
 
     @BeforeAll
     public static void init() {
@@ -43,19 +36,14 @@ class TestItemStackUtil {
         MockBukkit.unmock();
     }
 
-    @ParameterizedTest
-    @MethodSource("itemMaterials")
-    void testConsumerIsInvokedOnceIfMetaIsNotNull(Material material) {
-        ItemStack itemStack = new ItemStack(material);
-        ItemMeta meta = itemStack.getItemMeta();
+    @Test
+    void testConsumerIsInvokedOnceIfMetaIsNotNull() {
+        ItemStack itemStack = new ItemStack(Material.AIR);
+        itemStack.setItemMeta(new ItemMetaMock());
         ConsumerInvocationCounter<ItemMeta> counter = new ConsumerInvocationCounter<>();
         ItemStackUtil.editMeta(itemStack, counter);
-        if (meta == null) {
-            Assertions.assertFalse(counter.wasInvoked());
-        } else {
-            Assertions.assertTrue(counter.wasInvoked());
-            Assertions.assertEquals(1, counter.getInvokeCount());
-        }
+        Assertions.assertTrue(counter.wasInvoked());
+        Assertions.assertEquals(1, counter.getInvokeCount());
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -227,7 +227,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0-M7</version>
+                <version>3.3.1</version>
 
                 <configuration>
                     <junitArtifactName>org.junit.jupiter:junit-jupiter</junitArtifactName>
@@ -283,11 +283,23 @@
         </repository>
     </repositories>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>5.10.3</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>io.papermc.paper</groupId>
             <artifactId>paper-api</artifactId>
-            <version>1.18.1-R0.1-SNAPSHOT</version>
+            <version>1.18.2-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
 
@@ -301,7 +313,6 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.9.3</version>
             <scope>test</scope>
         </dependency>
 
@@ -315,7 +326,7 @@
         <dependency>
             <groupId>com.github.seeseemelk</groupId>
             <artifactId>MockBukkit-v1.18</artifactId>
-            <version>1.26.1</version>
+            <version>2.85.2</version>
             <scope>test</scope>
 
             <exclusions>


### PR DESCRIPTION
Refactors CustomItemStack to no longer extend ItemStack. All CIS constructors (except the color ctor) are now replaced with .create() methods with identical arguments. Additionally an ItemStackEditor fluent class with helper methods to edit the `ItemMeta` on an `ItemStack` is the builder equivalent.
Example: 
```
ItemStack item = new CustomItemStack(...);
```
With
```
ItemStack item = CustomItemStack.create(...);
```
or
```
ItemStack item = new ItemStackEditor(material).setX(...).setX(...).create();
