### PR TITLE
Fix: handle null lore properly

### DIFF
--- a/dough-items/src/main/java/io/github/bakedlibs/dough/items/CustomItemStack.java
+++ b/dough-items/src/main/java/io/github/bakedlibs/dough/items/CustomItemStack.java
@@ -25,10 +25,11 @@ public final class CustomItemStack {
     }
 
     public static ItemStack create(ItemStack item, @Nullable String name, String... lore) {
-        return new ItemStackEditor(item)
-                .setDisplayName(name)
-                .setLore(lore)
-                .create();
+        ItemStackEditor editor = new ItemStackEditor(item).setDisplayName(name);
+        if (lore != null) {
+            editor.setLore(lore);
+        }
+        return editor.create();
     }
 
     public static ItemStack create(Material material, @Nullable String name, String... lore) {


### PR DESCRIPTION
If an item is created without modifying its lore, its lore is automatically set to null rather than retaining that of the base item.

I made this change because, in the Walshy/mc-1.21 branch of Slimefun, when using the Altar, the lore gets removed since the empty lore overrides the base item's lore. I believe it's more appropriate to apply the fix here rather than in Slimefun, but I've prepared the other fix just in case.